### PR TITLE
Fixed source for modern Visual Studio compilers.

### DIFF
--- a/src/btrfs_drv.h
+++ b/src/btrfs_drv.h
@@ -76,8 +76,6 @@
 
 // #pragma pack(push, 1)
 
-struct device_extension;
-
 typedef struct {
     PDEVICE_OBJECT devobj;
     BTRFS_UUID fsuuid;

--- a/src/cache.c
+++ b/src/cache.c
@@ -21,7 +21,7 @@
 CACHE_MANAGER_CALLBACKS* cache_callbacks;
 
 static BOOLEAN STDCALL acquire_for_lazy_write(PVOID Context, BOOLEAN Wait) {
-    fcb* fcb = Context;
+    fcb* fcb = (_fcb*)Context;
     
     TRACE("(%p, %u)\n", Context, Wait);
     
@@ -31,7 +31,7 @@ static BOOLEAN STDCALL acquire_for_lazy_write(PVOID Context, BOOLEAN Wait) {
 }
 
 static void STDCALL release_from_lazy_write(PVOID Context) {
-    fcb* fcb = Context;
+    fcb* fcb = (_fcb*)Context;
     
     TRACE("(%p)\n", Context);
     
@@ -49,16 +49,16 @@ static void STDCALL release_from_read_ahead(PVOID Context) {
 }
 
 NTSTATUS STDCALL init_cache() {
-    cache_callbacks = ExAllocatePoolWithTag(NonPagedPool, sizeof(CACHE_MANAGER_CALLBACKS), ALLOC_TAG);
+    cache_callbacks = (CACHE_MANAGER_CALLBACKS*)ExAllocatePoolWithTag(NonPagedPool, sizeof(CACHE_MANAGER_CALLBACKS), ALLOC_TAG);
     if (!cache_callbacks) {
         ERR("out of memory\n");
         return STATUS_INSUFFICIENT_RESOURCES;
     }
     
-    cache_callbacks->AcquireForLazyWrite = acquire_for_lazy_write;
-    cache_callbacks->ReleaseFromLazyWrite = release_from_lazy_write;
-    cache_callbacks->AcquireForReadAhead = acquire_for_read_ahead;
-    cache_callbacks->ReleaseFromReadAhead = release_from_read_ahead;
+    cache_callbacks->AcquireForLazyWrite = (PACQUIRE_FOR_LAZY_WRITE)acquire_for_lazy_write;
+    cache_callbacks->ReleaseFromLazyWrite = (PRELEASE_FROM_LAZY_WRITE)release_from_lazy_write;
+    cache_callbacks->AcquireForReadAhead = (PACQUIRE_FOR_READ_AHEAD)acquire_for_read_ahead;
+    cache_callbacks->ReleaseFromReadAhead = (PRELEASE_FROM_READ_AHEAD)release_from_read_ahead;
     
     return STATUS_SUCCESS;
 }

--- a/src/crc32c.c
+++ b/src/crc32c.c
@@ -16,7 +16,11 @@
  * along with WinBtrfs.  If not, see <http://www.gnu.org/licenses/>. */
 
 #include <windef.h>
+#if (_MSC_VER < 1600) // Visual Studio 2008 and older.
 #include <smmintrin.h>
+#else
+#include <nmmintrin.h>
+#endif
 
 extern BOOL have_sse42;
 

--- a/src/create.c
+++ b/src/create.c
@@ -66,7 +66,7 @@ BOOL STDCALL find_file_in_dir_with_crc32(device_extension* Vcb, PUNICODE_STRING 
                 if (!NT_SUCCESS(Status)) {
                     ERR("RtlUTF8ToUnicodeN 1 returned %08x\n", Status);
                 } else {
-                    WCHAR* utf16 = ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
+                    WCHAR* utf16 = (WCHAR*)ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
                     UNICODE_STRING us;
                     
                     if (!utf16) {
@@ -101,7 +101,7 @@ BOOL STDCALL find_file_in_dir_with_crc32(device_extension* Vcb, PUNICODE_STRING 
                             if (utf8) {
                                 utf8->MaximumLength = di->n;
                                 utf8->Length = utf8->MaximumLength;
-                                utf8->Buffer = ExAllocatePoolWithTag(PagedPool, utf8->MaximumLength, ALLOC_TAG);
+                                utf8->Buffer = (PCHAR)ExAllocatePoolWithTag(PagedPool, utf8->MaximumLength, ALLOC_TAG);
                                 if (!utf8->Buffer) {
                                     ERR("out of memory\n");
                                     free_traverse_ptr(&tp);
@@ -172,7 +172,7 @@ BOOL STDCALL find_file_in_dir_with_crc32(device_extension* Vcb, PUNICODE_STRING 
             if (!NT_SUCCESS(Status)) {
                 ERR("RtlUTF8ToUnicodeN 1 returned %08x\n", Status);
             } else {
-                WCHAR* utf16 = ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
+                WCHAR* utf16 = (WCHAR*)ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
                 UNICODE_STRING us;
                 
                 if (!utf16) {
@@ -209,7 +209,7 @@ BOOL STDCALL find_file_in_dir_with_crc32(device_extension* Vcb, PUNICODE_STRING 
                         if (utf8) {
                             utf8->MaximumLength = di->n;
                             utf8->Length = utf8->MaximumLength;
-                            utf8->Buffer = ExAllocatePoolWithTag(PagedPool, utf8->MaximumLength, ALLOC_TAG);
+                            utf8->Buffer = (PCHAR)ExAllocatePoolWithTag(PagedPool, utf8->MaximumLength, ALLOC_TAG);
                             if (!utf8->Buffer) {
                                 ERR("out of memory\n");
                                 free_traverse_ptr(&tp);
@@ -250,7 +250,7 @@ BOOL STDCALL find_file_in_dir_with_crc32(device_extension* Vcb, PUNICODE_STRING 
 fcb* create_fcb() {
     fcb* fcb;
     
-    fcb = ExAllocatePoolWithTag(PagedPool, sizeof(struct _fcb), ALLOC_TAG);
+    fcb = (_fcb*)ExAllocatePoolWithTag(PagedPool, sizeof(struct _fcb), ALLOC_TAG);
     if (!fcb) {
         ERR("out of memory\n");
         return NULL;
@@ -264,7 +264,7 @@ fcb* create_fcb() {
     fcb->Header.NodeTypeCode = BTRFS_NODE_TYPE_FCB;
     fcb->Header.NodeByteSize = sizeof(struct _fcb);
     
-    fcb->nonpaged = ExAllocatePoolWithTag(NonPagedPool, sizeof(struct _fcb_nonpaged), ALLOC_TAG);
+    fcb->nonpaged = (_fcb_nonpaged*)ExAllocatePoolWithTag(NonPagedPool, sizeof(struct _fcb_nonpaged), ALLOC_TAG);
     if (!fcb->nonpaged) {
         ERR("out of memory\n");
         ExFreePool(fcb);
@@ -304,7 +304,7 @@ static BOOL STDCALL find_file_in_dir(device_extension* Vcb, PUNICODE_STRING file
         return FALSE;
     }
     
-    fn = ExAllocatePoolWithTag(PagedPool, utf8len, ALLOC_TAG);
+    fn = (char*)ExAllocatePoolWithTag(PagedPool, utf8len, ALLOC_TAG);
     if (!fn) {
         ERR("out of memory\n");
         return FALSE;
@@ -349,7 +349,7 @@ static BOOL find_stream(device_extension* Vcb, fcb* fcb, PUNICODE_STRING stream,
     
     TRACE("utf8len = %u\n", utf8len);
     
-    utf8 = ExAllocatePoolWithTag(PagedPool, xapreflen + utf8len + 1, ALLOC_TAG);
+    utf8 = (char*)ExAllocatePoolWithTag(PagedPool, xapreflen + utf8len + 1, ALLOC_TAG);
     if (!utf8) {
         ERR("out of memory\n");
         goto end;
@@ -401,7 +401,7 @@ static BOOL find_stream(device_extension* Vcb, fcb* fcb, PUNICODE_STRING stream,
                     *size = di->m;
                     *hash = tp.item->key.offset;
                     
-                    xattr->Buffer = ExAllocatePoolWithTag(PagedPool, di->n + 1, ALLOC_TAG);
+                    xattr->Buffer = (PCHAR)ExAllocatePoolWithTag(PagedPool, di->n + 1, ALLOC_TAG);
                     if (!xattr->Buffer) {
                         ERR("out of memory\n");
                         free_traverse_ptr(&tp);
@@ -462,7 +462,7 @@ static BOOL find_stream(device_extension* Vcb, fcb* fcb, PUNICODE_STRING stream,
                     if (!NT_SUCCESS(Status)) {
                         ERR("RtlUTF8ToUnicodeN 1 returned %08x\n", Status);
                     } else {
-                        WCHAR* utf16 = ExAllocatePoolWithTag(PagedPool, utf16len, ALLOC_TAG);
+                        WCHAR* utf16 = (WCHAR*)ExAllocatePoolWithTag(PagedPool, utf16len, ALLOC_TAG);
                         if (!utf16) {
                             ERR("out of memory\n");
                             free_traverse_ptr(&tp);
@@ -486,7 +486,7 @@ static BOOL find_stream(device_extension* Vcb, fcb* fcb, PUNICODE_STRING stream,
                                 *size = di->m;
                                 *hash = tp.item->key.offset;
                                 
-                                xattr->Buffer = ExAllocatePoolWithTag(PagedPool, di->n + 1, ALLOC_TAG);
+                                xattr->Buffer = (PCHAR)ExAllocatePoolWithTag(PagedPool, di->n + 1, ALLOC_TAG);
                                 if (!xattr->Buffer) {
                                     ERR("out of memory\n");
                                     free_traverse_ptr(&tp);
@@ -562,7 +562,7 @@ static NTSTATUS split_path(PUNICODE_STRING path, UNICODE_STRING** parts, ULONG* 
     if (has_stream)
         np++;
     
-    ps = ExAllocatePoolWithTag(PagedPool, np * sizeof(UNICODE_STRING), ALLOC_TAG);
+    ps = (UNICODE_STRING*)ExAllocatePoolWithTag(PagedPool, np * sizeof(UNICODE_STRING), ALLOC_TAG);
     if (!ps) {
         ERR("out of memory\n");
         return STATUS_INSUFFICIENT_RESOURCES;
@@ -676,7 +676,7 @@ static void print_fcbs(device_extension* Vcb) {
 #endif
 
 NTSTATUS get_fcb(device_extension* Vcb, fcb** pfcb, PUNICODE_STRING fnus, fcb* relatedfcb, BOOL parent) {
-    fcb *dir, *sf, *sf2;
+    fcb *dir, *sf, *sf2 = NULL;
     ULONG i, num_parts;
     UNICODE_STRING fnus2;
     UNICODE_STRING* parts = NULL;
@@ -802,7 +802,7 @@ NTSTATUS get_fcb(device_extension* Vcb, fcb** pfcb, PUNICODE_STRING fnus, fcb* r
                         sf2->filepart = streamname;
                     else {
                         sf2->filepart.MaximumLength = sf2->filepart.Length = parts[i].Length;
-                        sf2->filepart.Buffer = ExAllocatePoolWithTag(PagedPool, sf2->filepart.MaximumLength, ALLOC_TAG);
+                        sf2->filepart.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, sf2->filepart.MaximumLength, ALLOC_TAG);
                         if (!sf2->filepart.Buffer) {
                             ERR("out of memory\n");
                             free_fcb(sf2);
@@ -843,7 +843,7 @@ NTSTATUS get_fcb(device_extension* Vcb, fcb** pfcb, PUNICODE_STRING fnus, fcb* r
                     
                     fnlen = (sf2->name_offset * sizeof(WCHAR)) + sf2->filepart.Length;
                     
-                    sf2->full_filename.Buffer = ExAllocatePoolWithTag(PagedPool, fnlen, ALLOC_TAG);
+                    sf2->full_filename.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, fnlen, ALLOC_TAG);
                     if (!sf2->full_filename.Buffer) {
                         ERR("out of memory\n");
                         free_fcb(sf2);
@@ -901,7 +901,7 @@ NTSTATUS get_fcb(device_extension* Vcb, fcb** pfcb, PUNICODE_STRING fnus, fcb* r
                         goto end;
                     } else {
                         sf2->filepart.MaximumLength = sf2->filepart.Length = strlen;
-                        sf2->filepart.Buffer = ExAllocatePoolWithTag(PagedPool, sf2->filepart.MaximumLength, ALLOC_TAG);
+                        sf2->filepart.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, sf2->filepart.MaximumLength, ALLOC_TAG);
                         if (!sf2->filepart.Buffer) {
                             ERR("out of memory\n");
                             free_fcb(sf2);
@@ -942,7 +942,7 @@ NTSTATUS get_fcb(device_extension* Vcb, fcb** pfcb, PUNICODE_STRING fnus, fcb* r
                     
                     fnlen = (sf2->name_offset * sizeof(WCHAR)) + sf2->filepart.Length;
                     
-                    sf2->full_filename.Buffer = ExAllocatePoolWithTag(PagedPool, fnlen, ALLOC_TAG);
+                    sf2->full_filename.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, fnlen, ALLOC_TAG);
                     if (!sf2->full_filename.Buffer) {
                         ERR("out of memory\n");
                         free_fcb(sf2);
@@ -1053,7 +1053,7 @@ static NTSTATUS STDCALL file_create2(PIRP Irp, device_extension* Vcb, PUNICODE_S
     if (!NT_SUCCESS(Status))
         return Status;
     
-    utf8 = ExAllocatePoolWithTag(PagedPool, utf8len + 1, ALLOC_TAG);
+    utf8 = (char*)ExAllocatePoolWithTag(PagedPool, utf8len + 1, ALLOC_TAG);
     if (!utf8) {
         ERR("out of memory\n");
         return STATUS_INSUFFICIENT_RESOURCES;
@@ -1107,7 +1107,7 @@ static NTSTATUS STDCALL file_create2(PIRP Irp, device_extension* Vcb, PUNICODE_S
         return STATUS_INTERNAL_ERROR;
     }
     
-    dirii = ExAllocatePoolWithTag(PagedPool, sizeof(INODE_ITEM), ALLOC_TAG);
+    dirii = (INODE_ITEM*)ExAllocatePoolWithTag(PagedPool, sizeof(INODE_ITEM), ALLOC_TAG);
     if (!dirii) {
         ERR("out of memory\n");
         free_traverse_ptr(&tp);
@@ -1130,7 +1130,7 @@ static NTSTATUS STDCALL file_create2(PIRP Irp, device_extension* Vcb, PUNICODE_S
     type = options & FILE_DIRECTORY_FILE ? BTRFS_TYPE_DIRECTORY : BTRFS_TYPE_FILE;
     
     disize = sizeof(DIR_ITEM) - 1 + utf8len;
-    di = ExAllocatePoolWithTag(PagedPool, disize, ALLOC_TAG);
+    di = (DIR_ITEM*)ExAllocatePoolWithTag(PagedPool, disize, ALLOC_TAG);
     if (!di) {
         ERR("out of memory\n");
         ExFreePool(utf8);
@@ -1148,7 +1148,7 @@ static NTSTATUS STDCALL file_create2(PIRP Irp, device_extension* Vcb, PUNICODE_S
     
     insert_tree_item(Vcb, parfcb->subvol, parfcb->inode, TYPE_DIR_INDEX, dirpos, di, disize, NULL, rollback);
     
-    di2 = ExAllocatePoolWithTag(PagedPool, disize, ALLOC_TAG);
+    di2 = (DIR_ITEM*)ExAllocatePoolWithTag(PagedPool, disize, ALLOC_TAG);
     if (!di2) {
         ERR("out of memory\n");
         ExFreePool(utf8);
@@ -1295,7 +1295,7 @@ static NTSTATUS STDCALL file_create2(PIRP Irp, device_extension* Vcb, PUNICODE_S
     
     fcb->full_filename.Length = parfcb->full_filename.Length + (parfcb->full_filename.Length == sizeof(WCHAR) ? 0 : sizeof(WCHAR)) + fcb->filepart.Length;
     fcb->full_filename.MaximumLength = fcb->full_filename.Length;
-    fcb->full_filename.Buffer = ExAllocatePoolWithTag(PagedPool, fcb->full_filename.Length, ALLOC_TAG);
+    fcb->full_filename.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, fcb->full_filename.Length, ALLOC_TAG);
     if (!fcb->full_filename.Buffer) {
         ERR("out of memory\n");
         ExFreePool(utf8);
@@ -1309,7 +1309,7 @@ static NTSTATUS STDCALL file_create2(PIRP Irp, device_extension* Vcb, PUNICODE_S
     
     RtlCopyMemory(&fcb->full_filename.Buffer[(parfcb->full_filename.Length / sizeof(WCHAR)) + (parfcb->full_filename.Length == sizeof(WCHAR) ? 0 : 1)], fcb->filepart.Buffer, fcb->filepart.Length);
     
-    ii = ExAllocatePoolWithTag(PagedPool, sizeof(INODE_ITEM), ALLOC_TAG);
+    ii = (INODE_ITEM*)ExAllocatePoolWithTag(PagedPool, sizeof(INODE_ITEM), ALLOC_TAG);
     if (!ii) {
         ERR("out of memory\n");
         ExFreePool(utf8);
@@ -1352,7 +1352,7 @@ static NTSTATUS STDCALL file_create(PIRP Irp, device_extension* Vcb, PFILE_OBJEC
     // FIXME - apparently you can open streams using RelatedFileObject. How can we test this?
     
     ExAcquireResourceExclusiveLite(&Vcb->fcb_lock, TRUE);
-    Status = get_fcb(Vcb, &parfcb, fnus, FileObject->RelatedFileObject ? FileObject->RelatedFileObject->FsContext : NULL, TRUE);
+    Status = get_fcb(Vcb, &parfcb, fnus, (_fcb*)(FileObject->RelatedFileObject ? FileObject->RelatedFileObject->FsContext : NULL), TRUE);
     ExReleaseResourceLite(&Vcb->fcb_lock);
     if (!NT_SUCCESS(Status))
         goto end;
@@ -1375,7 +1375,7 @@ static NTSTATUS STDCALL file_create(PIRP Irp, device_extension* Vcb, PFILE_OBJEC
     while (fnus->Buffer[i-1] != '\\' && fnus->Buffer[i-1] != '/' && i > 0) { i--; }
     
     fpus.MaximumLength = (j - i + 2) * sizeof(WCHAR);
-    fpus.Buffer = ExAllocatePoolWithTag(PagedPool, fpus.MaximumLength, ALLOC_TAG);
+    fpus.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, fpus.MaximumLength, ALLOC_TAG);
     if (!fpus.Buffer) {
         ERR("out of memory\n");
         Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1498,7 +1498,7 @@ static NTSTATUS STDCALL file_create(PIRP Irp, device_extension* Vcb, PFILE_OBJEC
         
         fcb->adsxattr.Length = utf8len + xapreflen;
         fcb->adsxattr.MaximumLength = fcb->adsxattr.Length + 1;
-        fcb->adsxattr.Buffer = ExAllocatePoolWithTag(PagedPool, fcb->adsxattr.MaximumLength, ALLOC_TAG);
+        fcb->adsxattr.Buffer = (PCHAR)ExAllocatePoolWithTag(PagedPool, fcb->adsxattr.MaximumLength, ALLOC_TAG);
         if (!fcb->adsxattr.Buffer) {
             ERR("out of memory\n");
             free_fcb(fcb);
@@ -1526,7 +1526,7 @@ static NTSTATUS STDCALL file_create(PIRP Irp, device_extension* Vcb, PFILE_OBJEC
             fcb->name_offset++;
 
         fcb->filepart.MaximumLength = fcb->filepart.Length = stream.Length;
-        fcb->filepart.Buffer = ExAllocatePoolWithTag(PagedPool, fcb->filepart.MaximumLength, ALLOC_TAG);
+        fcb->filepart.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, fcb->filepart.MaximumLength, ALLOC_TAG);
         if (!fcb->filepart.Buffer) {
             ERR("out of memory\n");
             free_fcb(fcb);
@@ -1538,7 +1538,7 @@ static NTSTATUS STDCALL file_create(PIRP Irp, device_extension* Vcb, PFILE_OBJEC
         
         fnlen = (fcb->name_offset * sizeof(WCHAR)) + fcb->filepart.Length;
 
-        fcb->full_filename.Buffer = ExAllocatePoolWithTag(PagedPool, fnlen, ALLOC_TAG);
+        fcb->full_filename.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, fnlen, ALLOC_TAG);
         if (!fcb->full_filename.Buffer) {
             ERR("out of memory\n");
             free_fcb(fcb);
@@ -1588,7 +1588,7 @@ static NTSTATUS STDCALL file_create(PIRP Irp, device_extension* Vcb, PFILE_OBJEC
         
         free_traverse_ptr(&tp);
         
-        ii = ExAllocatePoolWithTag(PagedPool, sizeof(INODE_ITEM), ALLOC_TAG);
+        ii = (INODE_ITEM*)ExAllocatePoolWithTag(PagedPool, sizeof(INODE_ITEM), ALLOC_TAG);
         if (!ii) {
             ERR("out of memory\n");
             Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1625,7 +1625,7 @@ static NTSTATUS STDCALL file_create(PIRP Irp, device_extension* Vcb, PFILE_OBJEC
     
     Status = attach_fcb_to_fileobject(Vcb, fcb, FileObject);
     
-    ccb = ExAllocatePoolWithTag(NonPagedPool, sizeof(*ccb), ALLOC_TAG);
+    ccb = (_ccb*)ExAllocatePoolWithTag(NonPagedPool, sizeof(*ccb), ALLOC_TAG);
     if (!ccb) {
         ERR("out of memory\n");
         Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1662,7 +1662,7 @@ static NTSTATUS STDCALL file_create(PIRP Irp, device_extension* Vcb, PFILE_OBJEC
         
         fnlen = (fcb->name_offset * sizeof(WCHAR)) + fcb->filepart.Length;
         
-        fcb->full_filename.Buffer = ExAllocatePoolWithTag(PagedPool, fnlen, ALLOC_TAG);
+        fcb->full_filename.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, fnlen, ALLOC_TAG);
         if (!fcb->full_filename.Buffer) {
             ERR("out of memory\n");
             Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1842,7 +1842,7 @@ static NTSTATUS update_inode_item(device_extension* Vcb, root* subvol, UINT64 in
     
     free_traverse_ptr(&tp);
     
-    newii = ExAllocatePoolWithTag(PagedPool, sizeof(INODE_ITEM), ALLOC_TAG);
+    newii = (INODE_ITEM*)ExAllocatePoolWithTag(PagedPool, sizeof(INODE_ITEM), ALLOC_TAG);
     if (!newii) {
         ERR("out of memory\n");
         return STATUS_INSUFFICIENT_RESOURCES;
@@ -1863,7 +1863,7 @@ static NTSTATUS STDCALL create_file(PDEVICE_OBJECT DeviceObject, PIRP Irp, LIST_
     NTSTATUS Status;
     fcb* fcb;
     ccb* ccb;
-    device_extension* Vcb = DeviceObject->DeviceExtension;
+    device_extension* Vcb = (device_extension*)DeviceObject->DeviceExtension;
     
     Stack = IoGetCurrentIrpStackLocation(Irp);
     
@@ -1924,7 +1924,7 @@ static NTSTATUS STDCALL create_file(PDEVICE_OBJECT DeviceObject, PIRP Irp, LIST_
     // FIXME - if Vcb->readonly or subvol readonly, don't allow the write ACCESS_MASK flags
 
     ExAcquireResourceExclusiveLite(&Vcb->fcb_lock, TRUE);
-    Status = get_fcb(Vcb, &fcb, &FileObject->FileName, FileObject->RelatedFileObject ? FileObject->RelatedFileObject->FsContext : NULL, Stack->Flags & SL_OPEN_TARGET_DIRECTORY);
+    Status = get_fcb(Vcb, &fcb, &FileObject->FileName, (_fcb*)(FileObject->RelatedFileObject ? FileObject->RelatedFileObject->FsContext : NULL), Stack->Flags & SL_OPEN_TARGET_DIRECTORY);
     ExReleaseResourceLite(&Vcb->fcb_lock);
     
     if (NT_SUCCESS(Status) && fcb->deleted) {
@@ -2090,7 +2090,7 @@ static NTSTATUS STDCALL create_file(PDEVICE_OBJECT DeviceObject, PIRP Irp, LIST_
         if (options & FILE_DELETE_ON_CLOSE)
             fcb->delete_on_close = TRUE;
         
-        ccb = ExAllocatePoolWithTag(NonPagedPool, sizeof(*ccb), ALLOC_TAG);
+        ccb = (_ccb*)ExAllocatePoolWithTag(NonPagedPool, sizeof(*ccb), ALLOC_TAG);
         if (!ccb) {
             ERR("out of memory\n");
             free_fcb(fcb);
@@ -2132,7 +2132,7 @@ static NTSTATUS STDCALL create_file(PDEVICE_OBJECT DeviceObject, PIRP Irp, LIST_
         
         fcb->open_count++;
     } else {
-        Status = file_create(Irp, DeviceObject->DeviceExtension, FileObject, &FileObject->FileName, RequestedDisposition, options, rollback);
+        Status = file_create(Irp, (device_extension*)DeviceObject->DeviceExtension, FileObject, &FileObject->FileName, RequestedDisposition, options, rollback);
         Irp->IoStatus.Information = NT_SUCCESS(Status) ? FILE_CREATED : 0;
         
 //         if (!NT_SUCCESS(Status))
@@ -2171,7 +2171,7 @@ NTSTATUS STDCALL drv_create(IN PDEVICE_OBJECT DeviceObject, IN PIRP Irp) {
         goto exit;
     }
     
-    Vcb = DeviceObject->DeviceExtension;
+    Vcb = (device_extension*)DeviceObject->DeviceExtension;
     ExAcquireResourceSharedLite(&Vcb->load_lock, TRUE);
     
     IrpSp = IoGetCurrentIrpStackLocation(Irp);
@@ -2254,7 +2254,7 @@ NTSTATUS STDCALL drv_create(IN PDEVICE_OBJECT DeviceObject, IN PIRP Irp) {
         TRACE("file name: %.*S\n", IrpSp->FileObject->FileName.Length / sizeof(WCHAR), IrpSp->FileObject->FileName.Buffer);
         
         if (IrpSp->FileObject->RelatedFileObject) {
-            fcb* relfcb = IrpSp->FileObject->RelatedFileObject->FsContext;
+            fcb* relfcb = (_fcb*)IrpSp->FileObject->RelatedFileObject->FsContext;
             
             if (relfcb)
                 TRACE("related file name = %.*S\n", relfcb->full_filename.Length / sizeof(WCHAR), relfcb->full_filename.Buffer);

--- a/src/dirctrl.c
+++ b/src/dirctrl.c
@@ -140,7 +140,7 @@ static NTSTATUS STDCALL query_dir_item(fcb* fcb, void* buf, LONG* len, PIRP Irp,
     switch (IrpSp->Parameters.QueryDirectory.FileInformationClass) {
         case FileBothDirectoryInformation:
         {
-            FILE_BOTH_DIR_INFORMATION* fbdi = buf;
+            FILE_BOTH_DIR_INFORMATION* fbdi = (FILE_BOTH_DIR_INFORMATION*)buf;
             
             TRACE("FileBothDirectoryInformation\n");
             
@@ -179,7 +179,7 @@ static NTSTATUS STDCALL query_dir_item(fcb* fcb, void* buf, LONG* len, PIRP Irp,
 
         case FileDirectoryInformation:
         {
-            FILE_DIRECTORY_INFORMATION* fdi = buf;
+            FILE_DIRECTORY_INFORMATION* fdi = (FILE_DIRECTORY_INFORMATION*)buf;
             
             TRACE("FileDirectoryInformation\n");
             
@@ -215,7 +215,7 @@ static NTSTATUS STDCALL query_dir_item(fcb* fcb, void* buf, LONG* len, PIRP Irp,
             
         case FileFullDirectoryInformation:
         {
-            FILE_FULL_DIR_INFORMATION* ffdi = buf;
+            FILE_FULL_DIR_INFORMATION* ffdi = (FILE_FULL_DIR_INFORMATION*)buf;
             
             TRACE("FileFullDirectoryInformation\n");
             
@@ -252,7 +252,7 @@ static NTSTATUS STDCALL query_dir_item(fcb* fcb, void* buf, LONG* len, PIRP Irp,
 
         case FileIdBothDirectoryInformation:
         {
-            FILE_ID_BOTH_DIR_INFORMATION* fibdi = buf;
+            FILE_ID_BOTH_DIR_INFORMATION* fibdi = (FILE_ID_BOTH_DIR_INFORMATION*)buf;
             
             TRACE("FileIdBothDirectoryInformation\n");
             
@@ -299,7 +299,7 @@ static NTSTATUS STDCALL query_dir_item(fcb* fcb, void* buf, LONG* len, PIRP Irp,
 
         case FileNamesInformation:
         {
-            FILE_NAMES_INFORMATION* fni = buf;
+            FILE_NAMES_INFORMATION* fni = (FILE_NAMES_INFORMATION*)buf;
             
             TRACE("FileNamesInformation\n");
             
@@ -481,8 +481,8 @@ static NTSTATUS STDCALL query_directory(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
 //     num_reads_orig = num_reads;
     
     IrpSp = IoGetCurrentIrpStackLocation(Irp);
-    fcb = IrpSp->FileObject->FsContext;
-    ccb = IrpSp->FileObject->FsContext2;
+    fcb = (_fcb*)IrpSp->FileObject->FsContext;
+    ccb = (_ccb*)IrpSp->FileObject->FsContext2;
     
     acquire_tree_lock(fcb->Vcb, FALSE);
     
@@ -612,7 +612,7 @@ static NTSTATUS STDCALL query_directory(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
             goto end;
         }
         
-        uni_fn = ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
+        uni_fn = (WCHAR*)ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
         if (!uni_fn) {
             ERR("out of memory\n");
             if (tp.tree) free_traverse_ptr(&tp);
@@ -643,7 +643,7 @@ static NTSTATUS STDCALL query_directory(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                     goto end;
                 }
                 
-                uni_fn = ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
+                uni_fn = (WCHAR*)ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
                 if (!uni_fn) {
                     ERR("out of memory\n");
                     if (tp.tree) free_traverse_ptr(&tp);
@@ -717,7 +717,7 @@ static NTSTATUS STDCALL query_directory(PDEVICE_OBJECT DeviceObject, PIRP Irp) {
                             goto end;
                         }
                         
-                        uni_fn = ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
+                        uni_fn = (WCHAR*)ExAllocatePoolWithTag(PagedPool, stringlen, ALLOC_TAG);
                         if (!uni_fn) {
                             ERR("out of memory\n");
                             if (tp.tree) free_traverse_ptr(&tp);
@@ -791,7 +791,7 @@ end:
 static NTSTATUS STDCALL notify_change_directory(device_extension* Vcb, PIRP Irp) {
     PIO_STACK_LOCATION IrpSp = IoGetCurrentIrpStackLocation(Irp);
     PFILE_OBJECT FileObject = IrpSp->FileObject;
-    fcb* fcb = FileObject->FsContext;
+    fcb* fcb = (_fcb*)FileObject->FsContext;
     NTSTATUS Status;
 //     WCHAR fn[MAX_PATH];
     
@@ -839,7 +839,7 @@ NTSTATUS STDCALL drv_directory_control(IN PDEVICE_OBJECT DeviceObject, IN PIRP I
     
     switch (func) {
         case IRP_MN_NOTIFY_CHANGE_DIRECTORY:
-            Status = notify_change_directory(DeviceObject->DeviceExtension, Irp);
+            Status = notify_change_directory((device_extension*)DeviceObject->DeviceExtension, Irp);
             break;
             
         case IRP_MN_QUERY_DIRECTORY:

--- a/src/fastio.c
+++ b/src/fastio.c
@@ -53,7 +53,7 @@ static BOOLEAN STDCALL fast_io_query_open(PIRP Irp, PFILE_NETWORK_OPEN_INFORMATI
 static BOOLEAN STDCALL fast_io_check_if_possible(PFILE_OBJECT FileObject, PLARGE_INTEGER FileOffset, ULONG Length, BOOLEAN Wait,
                                          ULONG LockKey, BOOLEAN CheckForReadOperation, PIO_STATUS_BLOCK IoStatus,
                                          PDEVICE_OBJECT DeviceObject) {
-    fcb* fcb = FileObject->FsContext;
+    fcb* fcb = (_fcb*)FileObject->FsContext;
     LARGE_INTEGER len2;
     
     TRACE("(%p, %llx, %x, %x, %x, %x, %p, %p)\n", FileObject, FileOffset->QuadPart, Length, Wait, LockKey, CheckForReadOperation, IoStatus, DeviceObject);
@@ -150,33 +150,33 @@ void __stdcall init_fast_io_dispatch(FAST_IO_DISPATCH** fiod) {
 
     FastIoDispatch.SizeOfFastIoDispatch = sizeof(FAST_IO_DISPATCH);
 
-    FastIoDispatch.FastIoCheckIfPossible = fast_io_check_if_possible;
+    FastIoDispatch.FastIoCheckIfPossible = (PFAST_IO_CHECK_IF_POSSIBLE)fast_io_check_if_possible;
     FastIoDispatch.FastIoRead = FsRtlCopyRead;
     FastIoDispatch.FastIoWrite = FsRtlCopyWrite;
-    FastIoDispatch.FastIoQueryBasicInfo = fast_query_basic_info;
-    FastIoDispatch.FastIoQueryStandardInfo = fast_query_standard_info;
-    FastIoDispatch.FastIoLock = fast_io_lock;
-    FastIoDispatch.FastIoUnlockSingle = fast_io_unlock_single;
-    FastIoDispatch.FastIoUnlockAll = fast_io_unlock_all;
-    FastIoDispatch.FastIoUnlockAllByKey = fast_io_unlock_all_by_key;
-    FastIoDispatch.FastIoDeviceControl = fast_io_device_control;
-    FastIoDispatch.AcquireFileForNtCreateSection = acquire_file_for_create_section;
-    FastIoDispatch.ReleaseFileForNtCreateSection = release_file_for_create_section;
-    FastIoDispatch.FastIoDetachDevice = fast_io_detach_device;
-    FastIoDispatch.FastIoQueryNetworkOpenInfo = fast_io_query_network_open_info;
-    FastIoDispatch.AcquireForModWrite = fast_io_acquire_for_mod_write;
-    FastIoDispatch.MdlRead = FsRtlMdlReadDev;
-    FastIoDispatch.MdlReadComplete = FsRtlMdlReadCompleteDev;
+    FastIoDispatch.FastIoQueryBasicInfo = (PFAST_IO_QUERY_BASIC_INFO)fast_query_basic_info;
+    FastIoDispatch.FastIoQueryStandardInfo = (PFAST_IO_QUERY_STANDARD_INFO)fast_query_standard_info;
+    FastIoDispatch.FastIoLock = (PFAST_IO_LOCK)fast_io_lock;
+    FastIoDispatch.FastIoUnlockSingle = (PFAST_IO_UNLOCK_SINGLE)fast_io_unlock_single;
+    FastIoDispatch.FastIoUnlockAll = (PFAST_IO_UNLOCK_ALL)fast_io_unlock_all;
+    FastIoDispatch.FastIoUnlockAllByKey = (PFAST_IO_UNLOCK_ALL_BY_KEY)fast_io_unlock_all_by_key;
+    FastIoDispatch.FastIoDeviceControl = (PFAST_IO_DEVICE_CONTROL)fast_io_device_control;
+    FastIoDispatch.AcquireFileForNtCreateSection = (PFAST_IO_ACQUIRE_FILE)acquire_file_for_create_section;
+    FastIoDispatch.ReleaseFileForNtCreateSection = (PFAST_IO_RELEASE_FILE)release_file_for_create_section;
+    FastIoDispatch.FastIoDetachDevice = (PFAST_IO_DETACH_DEVICE)fast_io_detach_device;
+    FastIoDispatch.FastIoQueryNetworkOpenInfo = (PFAST_IO_QUERY_NETWORK_OPEN_INFO)fast_io_query_network_open_info;
+    FastIoDispatch.AcquireForModWrite = (PFAST_IO_ACQUIRE_FOR_MOD_WRITE)fast_io_acquire_for_mod_write;
+    FastIoDispatch.MdlRead = (PFAST_IO_MDL_READ)FsRtlMdlReadDev;
+    FastIoDispatch.MdlReadComplete = (PFAST_IO_MDL_READ_COMPLETE)FsRtlMdlReadCompleteDev;
     FastIoDispatch.PrepareMdlWrite = FsRtlPrepareMdlWriteDev;
     FastIoDispatch.MdlWriteComplete = FsRtlMdlWriteCompleteDev;
-    FastIoDispatch.FastIoReadCompressed = fast_io_read_compressed;
-    FastIoDispatch.FastIoWriteCompressed = fast_io_write_compressed;
-    FastIoDispatch.MdlReadCompleteCompressed = fast_io_mdl_read_complete_compressed;
-    FastIoDispatch.MdlWriteCompleteCompressed = fast_io_mdl_write_complete_compressed;
-    FastIoDispatch.FastIoQueryOpen = fast_io_query_open;
-    FastIoDispatch.ReleaseForModWrite = fast_io_release_for_mod_write;
-    FastIoDispatch.AcquireForCcFlush = fast_io_acquire_for_ccflush;
-    FastIoDispatch.ReleaseForCcFlush = fast_io_release_for_ccflush;
+    FastIoDispatch.FastIoReadCompressed = (PFAST_IO_READ_COMPRESSED)fast_io_read_compressed;
+    FastIoDispatch.FastIoWriteCompressed = (PFAST_IO_WRITE_COMPRESSED)fast_io_write_compressed;
+    FastIoDispatch.MdlReadCompleteCompressed = (PFAST_IO_MDL_READ_COMPLETE_COMPRESSED)fast_io_mdl_read_complete_compressed;
+    FastIoDispatch.MdlWriteCompleteCompressed = (PFAST_IO_MDL_WRITE_COMPLETE_COMPRESSED)fast_io_mdl_write_complete_compressed;
+    FastIoDispatch.FastIoQueryOpen = (PFAST_IO_QUERY_OPEN)fast_io_query_open;
+    FastIoDispatch.ReleaseForModWrite = (PFAST_IO_RELEASE_FOR_MOD_WRITE)fast_io_release_for_mod_write;
+    FastIoDispatch.AcquireForCcFlush = (PFAST_IO_ACQUIRE_FOR_CCFLUSH)fast_io_acquire_for_ccflush;
+    FastIoDispatch.ReleaseForCcFlush = (PFAST_IO_RELEASE_FOR_CCFLUSH)fast_io_release_for_ccflush;
     
     *fiod = &FastIoDispatch;
 }

--- a/src/flushthread.c
+++ b/src/flushthread.c
@@ -41,7 +41,7 @@ static void do_flush(device_extension* Vcb) {
 }
 
 void STDCALL flush_thread(void* context) {
-    device_extension* Vcb = context;
+    device_extension* Vcb = (device_extension*)context;
     LARGE_INTEGER due_time;
     
     KeInitializeTimer(&Vcb->flush_thread_timer);

--- a/src/search.c
+++ b/src/search.c
@@ -61,7 +61,7 @@ static void STDCALL add_volume(PDEVICE_OBJECT mountmgr, PUNICODE_STRING us, PDEV
     TRACE("found BTRFS volume\n");
     
     tnsize = sizeof(MOUNTMGR_TARGET_NAME) - sizeof(WCHAR) + us->Length;
-    tn = ExAllocatePoolWithTag(NonPagedPool, tnsize, ALLOC_TAG);
+    tn = (MOUNTMGR_TARGET_NAME*)ExAllocatePoolWithTag(NonPagedPool, tnsize, ALLOC_TAG);
     if (!tn) {
         ERR("out of memory\n");
         return;
@@ -92,7 +92,7 @@ static void STDCALL add_volume(PDEVICE_OBJECT mountmgr, PUNICODE_STRING us, PDEV
     
     mmdltsize = sizeof(MOUNTMGR_DRIVE_LETTER_TARGET) - 1 + us->Length;
     
-    mmdlt = ExAllocatePoolWithTag(NonPagedPool, mmdltsize, ALLOC_TAG);
+    mmdlt = (MOUNTMGR_DRIVE_LETTER_TARGET*)ExAllocatePoolWithTag(NonPagedPool, mmdltsize, ALLOC_TAG);
     if (!mmdlt) {
         ERR("out of memory\n");
         return;
@@ -141,7 +141,7 @@ static void STDCALL test_vol(PDEVICE_OBJECT mountmgr, PUNICODE_STRING us, LIST_E
     
     us2.Length = ((wcslen(devpath) + 1) * sizeof(WCHAR)) + us->Length;
     us2.MaximumLength = us2.Length;
-    us2.Buffer = ExAllocatePoolWithTag(PagedPool, us2.Length, ALLOC_TAG);
+    us2.Buffer = (PWCH)ExAllocatePoolWithTag(PagedPool, us2.Length, ALLOC_TAG);
     if (!us2.Buffer) {
         ERR("out of memory\n");
         return;
@@ -164,7 +164,7 @@ static void STDCALL test_vol(PDEVICE_OBJECT mountmgr, PUNICODE_STRING us, LIST_E
     Offset.QuadPart = superblock_addrs[0];
     
     toread = sector_align(sizeof(superblock), DeviceObject->SectorSize);
-    data = ExAllocatePoolWithTag(NonPagedPool, toread, ALLOC_TAG);
+    data = (UINT8*)ExAllocatePoolWithTag(NonPagedPool, toread, ALLOC_TAG);
     if (!data) {
         ERR("out of memory\n");
         goto deref;
@@ -186,7 +186,7 @@ static void STDCALL test_vol(PDEVICE_OBJECT mountmgr, PUNICODE_STRING us, LIST_E
 
     if (NT_SUCCESS(Status) && IoStatusBlock.Information > 0 && ((superblock*)data)->magic == BTRFS_MAGIC) {
         superblock* sb = (superblock*)data;
-        volume* v = ExAllocatePoolWithTag(PagedPool, sizeof(volume), ALLOC_TAG);
+        volume* v = (volume*)ExAllocatePoolWithTag(PagedPool, sizeof(volume), ALLOC_TAG);
         if (!v) {
             ERR("out of memory\n");
             goto deref;
@@ -257,7 +257,7 @@ void STDCALL look_for_vols(LIST_ENTRY* volumes) {
     }
     
     odisize = sizeof(OBJECT_DIRECTORY_INFORMATION) * 16;
-    odi = ExAllocatePoolWithTag(PagedPool, odisize, ALLOC_TAG);
+    odi = (OBJECT_DIRECTORY_INFORMATION*)ExAllocatePoolWithTag(PagedPool, odisize, ALLOC_TAG);
     if (!odi) {
         ERR("out of memory\n");
         return;


### PR DESCRIPTION
This change makes the source compile successfully with the more recent MSVC tool sets.
This will NOT break compilation using older (like Visual Studio 2008) suites.

Mainly, this change does two things:
- Removes circular references within struct types.
- Explicitly casts some types from PVOID, which modern compilers wouldn't accept.
