### PR TITLE
Few fixes to WinBtrfs driver

### DIFF
--- a/src/btrfs.c
+++ b/src/btrfs.c
@@ -4700,7 +4700,9 @@ NTSTATUS STDCALL DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING Regist
     DriverObject->MajorFunction[IRP_MJ_PNP]                      = (PDRIVER_DISPATCH)drv_pnp;
     DriverObject->MajorFunction[IRP_MJ_QUERY_SECURITY]           = (PDRIVER_DISPATCH)drv_query_security;
     DriverObject->MajorFunction[IRP_MJ_SET_SECURITY]             = (PDRIVER_DISPATCH)drv_set_security;
-    
+
+    init_fast_io_dispatch(&DriverObject->FastIoDispatch);
+
     device_nameW.Buffer = device_name;
     device_nameW.Length = device_nameW.MaximumLength = (USHORT)wcslen(device_name) * sizeof(WCHAR);
     dosdevice_nameW.Buffer = dosdevice_name;


### PR DESCRIPTION
Few fixes to the volume mounting process:
- Don't go again into the file system critical section, caller already acquired it
- Only set the VPB when it's established it's possible to mount the volume
- When failing reading superblock, return STATUS_UNRECOGNIZED_VOLUME to let other file systems have a try on mounting the volume
- Upon complete failure, free most of the allocated stuff

This avoids btrfs driver locking volumes it cannot mount because they are formatted with other file systems

Set FastIoDispatch on driver init; that avoids later null pointer dereference in FastIO code path.