### PR TITLE
Fix set_symlink() pointer cast

### DIFF
--- a/src/btrfs.c
+++ b/src/btrfs.c
@@ -1161,15 +1161,18 @@ static NTSTATUS STDCALL set_label(device_extension* Vcb, FILE_FS_LABEL_INFORMATI
     // FIXME - check for '/' and '\\' and reject
     
 //     utf8 = ExAllocatePoolWithTag(PagedPool, utf8len + 1, ALLOC_TAG);
-    
-    Status = RtlUnicodeToUTF8N((PCHAR)&Vcb->superblock.label, MAX_LABEL_SIZE * sizeof(WCHAR), &utf8len, ffli->VolumeLabel, ffli->VolumeLabelLength);
+
+    // Let's zero the buffer...
+    RtlZeroMemory(Vcb->superblock.label, MAX_LABEL_SIZE);
+
+    // ...now copy up to MAX_LABEL_SIZE.
+    Status = RtlUnicodeToUTF8N((PCHAR)&Vcb->superblock.label, MAX_LABEL_SIZE, &utf8len, ffli->VolumeLabel, ffli->VolumeLabelLength);
     if (!NT_SUCCESS(Status))
         goto release;
     
     ExAcquireResourceExclusiveLite(&Vcb->tree_lock, TRUE);
     
-    if (utf8len < MAX_LABEL_SIZE * sizeof(WCHAR))
-        RtlZeroMemory(Vcb->superblock.label + utf8len, (MAX_LABEL_SIZE * sizeof(WCHAR)) - utf8len);
+
     
 //     test_tree_deletion(Vcb); // TESTING
 //     test_tree_splitting(Vcb);

--- a/src/reparse.c
+++ b/src/reparse.c
@@ -134,6 +134,7 @@ end:
 static NTSTATUS set_symlink(PIRP Irp, file_ref* fileref, REPARSE_DATA_BUFFER* rdb, ULONG buflen, LIST_ENTRY* rollback) {
     NTSTATUS Status;
     ULONG minlen;
+    ULONG tlength;
     UNICODE_STRING subname;
     ANSI_STRING target;
     LARGE_INTEGER offset, time;
@@ -187,7 +188,8 @@ static NTSTATUS set_symlink(PIRP Irp, file_ref* fileref, REPARSE_DATA_BUFFER* rd
     }
     
     offset.QuadPart = 0;
-    Status = write_file2(fileref->fcb->Vcb, Irp, offset, target.Buffer, (ULONG*)&target.Length, FALSE, TRUE,
+    tlength = target.Length;
+    Status = write_file2(fileref->fcb->Vcb, Irp, offset, target.Buffer, &tlength, FALSE, TRUE,
                          TRUE, FALSE, rollback);
     ExFreePool(target.Buffer);
     


### PR DESCRIPTION
Fix wrong pointer cast in Write_file2() call in set_symlink function.
This was leading to flush more memory than intended in write_file2().