### PR TITLE
Fix copying and zeroing in set_label()

### DIFF
--- a/src/btrfs.c
+++ b/src/btrfs.c
@@ -1161,15 +1161,18 @@ static NTSTATUS STDCALL set_label(device_extension* Vcb, FILE_FS_LABEL_INFORMATI
     // FIXME - check for '/' and '\\' and reject
     
 //     utf8 = ExAllocatePoolWithTag(PagedPool, utf8len + 1, ALLOC_TAG);
-    
-    Status = RtlUnicodeToUTF8N((PCHAR)&Vcb->superblock.label, MAX_LABEL_SIZE * sizeof(WCHAR), &utf8len, ffli->VolumeLabel, ffli->VolumeLabelLength);
+
+    // Zeroing the whole buffer...
+    RtlZeroMemory(Vcb->superblock.label, MAX_LABEL_SIZE);
+
+    //...and now copying the label into it
+    Status = RtlUnicodeToUTF8N((PCHAR)&Vcb->superblock.label, MAX_LABEL_SIZE, &utf8len, ffli->VolumeLabel, ffli->VolumeLabelLength);
     if (!NT_SUCCESS(Status))
         goto release;
     
     ExAcquireResourceExclusiveLite(&Vcb->tree_lock, TRUE);
     
-    if (utf8len < MAX_LABEL_SIZE * sizeof(WCHAR))
-        RtlZeroMemory(Vcb->superblock.label + utf8len, (MAX_LABEL_SIZE * sizeof(WCHAR)) - utf8len);
+    
     
 //     test_tree_deletion(Vcb); // TESTING
 //     test_tree_splitting(Vcb);


### PR DESCRIPTION
* Fix the UTF8StringMaxByteCount param in RtlUnicodeToUTF8N to avoid overflowing the destiny "label" buffer which is char label[MAX_LABEL_SIZE].
* Remove the if check, since it was wrong, it should be if(utf8len <MAX_LABEL_SIZE), but it is redundant since RtlUnicodeToUTF8N won't never copy more than MAX_LABEL_SIZE bytes.
* Change the Zeroing logic: Instead copying and then zeroing the not used buffer the new logic  zeroes the whole buffer first and copies the string on top. The old logic was prone to errors, even more, the old
logic was corrupting memory zeroing bytes that it shouldn't.

Hope it helps. Keep up with the great work! :) 
