### PR TITLE
Fix leaking "data" in update_root_backref()

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -4652,6 +4652,8 @@ static NTSTATUS STDCALL update_root_backref(device_extension* Vcb, UINT64 subvol
     Status = find_item(Vcb, Vcb->root_root, &tp, &searchkey, FALSE);
     if (!NT_SUCCESS(Status)) {
         ERR("error - find_item returned %08x\n", Status);
+        if (data)
+            ExFreePool(data);
         return Status;
     }
     


### PR DESCRIPTION
Fix a leakage if not item is found.