### PR TITLE
[BTRFS/flushthread] Avoid a double free in do_tree_writes(), since write_data is already freeing "wtc" in the failure case.

### DIFF
--- a/src/flushthread.c
+++ b/src/flushthread.c
@@ -1606,7 +1606,6 @@ NTSTATUS do_tree_writes(device_extension* Vcb, LIST_ENTRY* tree_writes, PIRP Irp
                     for (i = 0; i < num_bits; i++) {
                         free_write_data_stripes(&wtc[i]);
                     }
-                    ExFreePool(wtc);
                     
                     return Status;
                 }


### PR DESCRIPTION
Avoid a double free in do_tree_writes(), since write_data is already freeing "wtc" in the failure case.
Maybe you'd prefer to remove the freeing in case of failure inside write_data() (write.c) and handle the failure case outside. 