### PR TITLE
Changes I needed to build on VC++2015 + Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ and 3 for absolutely everything, including traces.
 * `LogDevice` (string, optional): the serial device you want to output to, such as
 `\Device\Serial0`. This is probably only useful on virtual machines.
 * `LogFile` (string, optional): the file you wish to output to, if `LogDevice` isn't set.
-Bear in mind this is a kernel filename, so you'll have to prefix it with "\??\" (e.g.,
-"\??\C:\btrfs.log"). It probably goes without saying, but don't store this on a volume the
+Bear in mind this is a kernel filename, so you'll have to prefix it with "\\??\\" (e.g.,
+"\\??\\C:\\btrfs.log"). It probably goes without saying, but don't store this on a volume the
 driver itself is using, or you'll cause an infinite loop.
 
 Mount options

--- a/src/btrfs.rc
+++ b/src/btrfs.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winres.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -34,7 +34,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winres.h""\r\n"
     "\0"
 END
 

--- a/src/btrfs_drv.h
+++ b/src/btrfs_drv.h
@@ -24,6 +24,7 @@
 #define _WIN32_WINNT 0x0601
 #define NTDDI_VERSION 0x06010000 // Win 7
 #define _CRT_SECURE_NO_WARNINGS
+#define _NO_CRT_STDIO_INLINE
 
 #include <ntifs.h>
 #include <ntddk.h>

--- a/src/mkbtrfs/mkbtrfs.rc
+++ b/src/mkbtrfs/mkbtrfs.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winres.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -34,7 +34,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winres.h""\r\n"
     "\0"
 END
 

--- a/src/shellext/shellbtrfs.rc
+++ b/src/shellext/shellbtrfs.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winres.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -34,7 +34,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winres.h""\r\n"
     "\0"
 END
 

--- a/src/ubtrfs/ubtrfs.rc
+++ b/src/ubtrfs/ubtrfs.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include <winres.h>
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -34,7 +34,7 @@ END
 
 2 TEXTINCLUDE 
 BEGIN
-    "#include ""afxres.h""\r\n"
+    "#include ""winres.h""\r\n"
     "\0"
 END
 


### PR DESCRIPTION
- Using Windows SDK header instead of MFC header
Remove dependency on MFC.
- Avoid stdio inline
Will import APIs that are not in the kernel.
- README
I wondered why the log file could not be created.