### PR TITLE
[SHELLTEXT] Fix a suspecting buffer overflow

### DIFF
--- a/src/shellext/devices.cpp
+++ b/src/shellext/devices.cpp
@@ -900,7 +900,7 @@ static INT_PTR CALLBACK stub_DeviceResizeDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
 
 void BtrfsDeviceResize::ShowDialog(HWND hwnd, WCHAR* fn, UINT64 dev_id) {
     this->dev_id = dev_id;
-    wcscpy(this->fn, fn);
+    wcscpy_s(this->fn, _countof(fn), fn);
 
     DialogBoxParamW(module, MAKEINTRESOURCEW(IDD_RESIZE), hwnd, stub_DeviceResizeDlgProc, (LPARAM)this);
 }


### PR DESCRIPTION
## Purpose & Changes
Using `wcscpy()` for copying wide character strings is quite too risky, especially when `fn` variable within the parameters is too long and passes the buffer boundary (a.k.a. buffer overflow). 

Using `wcscpy_s` (the safe function of `wcscpy()`) should solve this undefined behaviour, the length is also measured.