### PR TITLE
query_directory function fix

### DIFF
--- a/src/dirctrl.c
+++ b/src/dirctrl.c
@@ -675,7 +675,7 @@ static NTSTATUS query_directory(PIRP Irp) {
     if (IrpSp->Parameters.QueryDirectory.FileName && IrpSp->Parameters.QueryDirectory.FileName->Length > 1) {
         TRACE("QD filename: %.*S\n", IrpSp->Parameters.QueryDirectory.FileName->Length / sizeof(WCHAR), IrpSp->Parameters.QueryDirectory.FileName->Buffer);
 
-        if (IrpSp->Parameters.QueryDirectory.FileName->Buffer[0] != '*') {
+        if (IrpSp->Parameters.QueryDirectory.FileName->Length > sizeof(WCHAR) || IrpSp->Parameters.QueryDirectory.FileName->Buffer[0] != L'*') {
             specific_file = TRUE;
 
             if (FsRtlDoesNameContainWildCards(IrpSp->Parameters.QueryDirectory.FileName)) {


### PR DESCRIPTION
Masks with `*` as beginning character were incorrectly handled: `*whatever` mask was treated like `*` and returned whole directory contents.