### PR TITLE
open_file: don't use non-initialized granted_access when the file_create() code path is taken.

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -2784,7 +2784,7 @@ static NTSTATUS open_file(PDEVICE_OBJECT DeviceObject, _Requires_lock_held_(_Cur
     ULONG fn_offset = 0;
     file_ref *related, *fileref = NULL;
     POOL_TYPE pool_type = IrpSp->Flags & SL_OPEN_PAGING_FILE ? NonPagedPool : PagedPool;
-    ACCESS_MASK granted_access;
+    ACCESS_MASK granted_access = 0;
     BOOL loaded_related = FALSE;
     UNICODE_STRING fn;
 #ifdef DEBUG_FCB_REFCOUNTS
@@ -3543,6 +3543,7 @@ static NTSTATUS open_file(PDEVICE_OBJECT DeviceObject, _Requires_lock_held_(_Cur
         open_type = 2;
 #endif
         Status = file_create(Irp, Vcb, FileObject, related, loaded_related, &fn, RequestedDisposition, options, rollback);
+        granted_access = 0;
         release_fcb_lock(Vcb);
 
         Irp->IoStatus.Information = NT_SUCCESS(Status) ? FILE_CREATED : 0;


### PR DESCRIPTION
This problem has been caught with Run-Time-Checks enabled on an MSVC build.

Step to reproduce: create a new directory that doesn't exist before, by calling the `open_file()` function with `RequestedDisposition == FILE_OPEN_IF`.

In this situation, the open_fileref() call fails with `Status == 0xC0000034 == STATUS_OBJECT_NAME_NOT_FOUND`, and the failure branch of the following test:
```c
if (NT_SUCCESS(Status)) { // file already exists
```
(since it's FALSE) is taken.
The following call is then performed:
```c
file_create(Irp, Vcb, FileObject, related, loaded_related, &fn, RequestedDisposition, options, rollback);
```
and returns STATUS_SUCCESS, and the `exit:` code block of open_file() is then taken. Nowhere was the `granted_access` variable being set.

(Please note that the `file_create()` function internally initializes a private `granted_access` variable...).