### PR TITLE
btrfs: don't allow bogus names on open

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -285,6 +285,9 @@ static NTSTATUS split_path(device_extension* Vcb, PUNICODE_STRING path, LIST_ENT
     if (len > 0 && (path->Buffer[len - 1] == '/' || path->Buffer[len - 1] == '\\'))
         len--;
 
+    if (len == 0 || (path->Buffer[len - 1] == '/' || path->Buffer[len - 1] == '\\'))
+        return STATUS_OBJECT_NAME_INVALID;
+
     has_stream = FALSE;
     for (i = 0; i < len; i++) {
         if (path->Buffer[i] == '/' || path->Buffer[i] == '\\') {
@@ -1464,7 +1467,8 @@ NTSTATUS open_fileref(_Requires_lock_held_(_Curr_->tree_lock) _Requires_exclusiv
                 *fn_offset = 0;
 
             return STATUS_SUCCESS;
-        }
+        } else if (fnus2.Length >= 2 * sizeof(WCHAR) && fnus2.Buffer[1] == '\\')
+            return STATUS_OBJECT_NAME_INVALID;
 
         dir = Vcb->root_fileref;
 

--- a/src/create.c
+++ b/src/create.c
@@ -356,8 +356,14 @@ static NTSTATUS split_path(device_extension* Vcb, PUNICODE_STRING path, LIST_ENT
                 nb2->us.Length = nb2->us.MaximumLength = (UINT16)(nb->us.Length - (i * sizeof(WCHAR)) - sizeof(WCHAR));
                 InsertTailList(parts, &nb2->list_entry);
 
-                nb->us.Length = (UINT16)i * sizeof(WCHAR);
-                nb->us.MaximumLength = nb->us.Length;
+                /* It's just a stream name, remove last name item */
+                if (i == 0) {
+                    RemoveEntryList(&nb->list_entry);
+                    ExFreeToPagedLookasideList(&Vcb->name_bit_lookaside, nb);
+                } else {
+                    nb->us.Length = (UINT16)i * sizeof(WCHAR);
+                    nb->us.MaximumLength = nb->us.Length;
+                }
 
                 nb = nb2;
 

--- a/src/create.c
+++ b/src/create.c
@@ -338,6 +338,11 @@ static NTSTATUS split_path(device_extension* Vcb, PUNICODE_STRING path, LIST_ENT
             if (nb->us.Buffer[i] == ':') {
                 name_bit* nb2;
 
+                if (nb->us.Buffer[i+1] == 0) {
+                    ERR("Bogus stream name\n");
+                    return STATUS_OBJECT_NAME_INVALID;
+                }
+
                 nb2 = ExAllocateFromPagedLookasideList(&Vcb->name_bit_lookaside);
                 if (!nb2) {
                     ERR("out of memory\n");

--- a/src/create.c
+++ b/src/create.c
@@ -298,6 +298,11 @@ static NTSTATUS split_path(device_extension* Vcb, PUNICODE_STRING path, LIST_ENT
 
     for (i = 0; i < len; i++) {
         if (path->Buffer[i] == '/' || path->Buffer[i] == '\\') {
+            if (buf[0] == '/' || buf[0] == '\\') {
+                ERR("Bogus name\n");
+                return STATUS_OBJECT_NAME_INVALID;
+            }
+
             nb = ExAllocateFromPagedLookasideList(&Vcb->name_bit_lookaside);
             if (!nb) {
                 ERR("out of memory\n");


### PR DESCRIPTION
This can be triggered by opening with a file name terminated by two \\ (like ReactOS\\ ;-)). In such situation, BtrFS will keep going and will attempt to upcase an empty string while parsing the name, which leads to a 0-sized allocation in the kernel. If that works on a free build, that triggers an ASSERT on checked builds.