### PR TITLE
shellext: Change function argument of command_line_to_args from value to reference

### DIFF
--- a/src/shellext/main.cpp
+++ b/src/shellext/main.cpp
@@ -569,7 +569,7 @@ extern "C" void CALLBACK CreateSnapshotW(HWND hwnd, HINSTANCE hinst, LPWSTR lpsz
         create_snapshot2(args[0], args[1]);
 }
 
-void command_line_to_args(LPWSTR cmdline, vector<wstring> args) {
+void command_line_to_args(LPWSTR cmdline, vector<wstring> &args) {
     LPWSTR* l;
     int num_args;
 

--- a/src/shellext/shellext.h
+++ b/src/shellext/shellext.h
@@ -310,7 +310,7 @@ wstring format_message(ULONG last_error);
 wstring format_ntstatus(NTSTATUS Status);
 bool load_string(HMODULE module, UINT id, wstring& s);
 void wstring_sprintf(wstring& s, wstring fmt, ...);
-void command_line_to_args(LPWSTR cmdline, vector<wstring> args);
+void command_line_to_args(LPWSTR cmdline, vector<wstring> &args);
 void utf8_to_utf16(const string& utf8, wstring& utf16);
 void utf16_to_utf8(const wstring& utf16, string& utf8);
 void error_message(HWND hwnd, const char* msg);


### PR DESCRIPTION
I tried to run those documented rundll commands (ex: CreateSubvol, CreateSnapshot, etc) and none of them worked. I wondered why. Then I downloaded, compiled and debugged the code and found the culprit. I guess that the function argument "args" in command_line_to_args is meant to be changed by the function right? The old code was doing pass by value, and not by reference.. After those changes, the code was executing successfully.