### PR TITLE
write_file2(): Fix a memory leak

### DIFF
--- a/src/write.c
+++ b/src/write.c
@@ -4471,9 +4471,11 @@ NTSTATUS write_file2(device_extension* Vcb, PIRP Irp, LARGE_INTEGER offset, void
             ed2->type = EXTENT_TYPE_INLINE;
 
             Status = add_extent_to_fcb(fcb, 0, ed2, (UINT16)(offsetof(EXTENT_DATA, data[0]) + newlength), FALSE, NULL, rollback);
+
+            ExFreePool(data);
+
             if (!NT_SUCCESS(Status)) {
                 ERR("add_extent_to_fcb returned %08x\n", Status);
-                ExFreePool(data);
                 goto end;
             }
 


### PR DESCRIPTION
See #164: ReactOS "overwrite" testcase.
Tested on ReactOS. It feels odd that you don't reproduce on Windows...

==>
- Please, double-check the missing free should happen there.
