### PR TITLE
open_file2: fix compilation with DEBUG_FCB_REFCOUNTS

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -2898,9 +2898,6 @@ static NTSTATUS file_create(PIRP Irp, _Requires_lock_held_(_Curr_->tree_lock) _R
     POOL_TYPE pool_type = IrpSp->Flags & SL_OPEN_PAGING_FILE ? NonPagedPool : PagedPool;
     ECP_LIST* ecp_list;
     ATOMIC_CREATE_ECP_CONTEXT* acec = NULL;
-#ifdef DEBUG_FCB_REFCOUNTS
-    LONG oc;
-#endif
 
     TRACE("(%p, %p, %p, %.*S, %x, %x)\n", Irp, Vcb, FileObject, fnus->Length / sizeof(WCHAR), fnus->Buffer, disposition, options);
 
@@ -3094,8 +3091,10 @@ static NTSTATUS file_create(PIRP Irp, _Requires_lock_held_(_Curr_->tree_lock) _R
     ccb->lxss = called_from_lxss();
 
 #ifdef DEBUG_FCB_REFCOUNTS
-    oc = InterlockedIncrement(&fileref->open_count);
+    {
+    LONG oc = InterlockedIncrement(&fileref->open_count);
     ERR("fileref %p: open_count now %i\n", fileref, oc);
+    }
 #else
     InterlockedIncrement(&fileref->open_count);
 #endif
@@ -3923,8 +3922,10 @@ static NTSTATUS open_file2(device_extension* Vcb, ULONG RequestedDisposition, PO
     }
 
 #ifdef DEBUG_FCB_REFCOUNTS
+    {
     LONG oc = InterlockedIncrement(&fileref->open_count);
     ERR("fileref %p: open_count now %i\n", fileref, oc);
+    }
 #else
     InterlockedIncrement(&fileref->open_count);
 #endif


### PR DESCRIPTION
`.../create.c:3957:5: error: ISO C90 forbids mixed declarations and code [-Werror=declaration-after-statement]`