### PR TITLE
open_file2: hack-fix compilation with DEBUG_STATS

### DIFF
--- a/src/create.c
+++ b/src/create.c
@@ -3450,9 +3450,12 @@ static NTSTATUS open_file2(device_extension* Vcb, ULONG RequestedDisposition, PO
     if (RequestedDisposition == FILE_SUPERSEDE || RequestedDisposition == FILE_OVERWRITE || RequestedDisposition == FILE_OVERWRITE_IF) {
         LARGE_INTEGER zero;
 
+/*
+// FIXME: open_type exists in open_file() only!
 #ifdef DEBUG_STATS
         open_type = 1;
 #endif
+*/
         if (fileref->fcb->type == BTRFS_TYPE_DIRECTORY || is_subvol_readonly(fileref->fcb->subvol, Irp)) {
             free_fileref(fileref);
 


### PR DESCRIPTION
`.../create.c:3485:9: error: 'open_type' undeclared (first use in this function)`

Broken since ab0a3d74e6b96c27b3dad4c7147d5117729f8ca5.

Feel free to commit an actual fix instead.