### PR TITLE
_free_fcb: remove duplicate ERR() code

### DIFF
--- a/src/btrfs.c
+++ b/src/btrfs.c
@@ -1460,11 +1460,7 @@ void free_fcb(_Inout_ fcb* fcb) {
 #endif
 
 #ifdef DEBUG_FCB_REFCOUNTS
-#ifdef DEBUG_LONG_MESSAGES
     ERR("fcb %p (%s): refcount now %i (subvol %llx, inode %llx)\n", fcb, func, rc, fcb->subvol ? fcb->subvol->id : 0, fcb->inode);
-#else
-    ERR("fcb %p (%s): refcount now %i (subvol %llx, inode %llx)\n", fcb, func, rc, fcb->subvol ? fcb->subvol->id : 0, fcb->inode);
-#endif
 #endif
 }
 


### PR DESCRIPTION
Leftover from cd21e344853525c31307042e92e1b156a70c5602.