### PR TITLE
clear_rollback: fix a memory leak in ROLLBACK_INSERT_EXTENT case

### DIFF
--- a/src/treefuncs.c
+++ b/src/treefuncs.c
@@ -1031,9 +1031,16 @@ void clear_rollback(LIST_ENTRY* rollback) {
         rollback_item* ri = CONTAINING_RECORD(le, rollback_item, list_entry);
 
         switch (ri->type) {
+            case ROLLBACK_INSERT_EXTENT:
+            {
+                rollback_extent* re = ri->ptr;
+
+                re->ext->ignore = TRUE;
+
+                // Fall through.
+            }
             case ROLLBACK_ADD_SPACE:
             case ROLLBACK_SUBTRACT_SPACE:
-            case ROLLBACK_INSERT_EXTENT:
             case ROLLBACK_DELETE_EXTENT:
                 ExFreePool(ri->ptr);
                 break;


### PR DESCRIPTION
See #164: ReactOS "recreate" testcase.

Memories allocated by `insert_extent_chunk() : csum` and `add_extent_to_fcb() : ext` are leaked.

This PR fixes 1+1 leaks,
but triggers ReactOS failures at a ReactOS Stage 1 step (Hive).

Is this fix correct, incomplete or wrong?

NB:
I have not checked if at least `ROLLBACK_DELETE_EXTENT` case would need some fix too...