### PR TITLE
DriverUnload: add missing parameter to a TRACE()

### DIFF
--- a/src/btrfs.c
+++ b/src/btrfs.c
@@ -270,7 +270,7 @@ _Function_class_(DRIVER_UNLOAD)
 static void DriverUnload(_In_ PDRIVER_OBJECT DriverObject) {
     UNICODE_STRING dosdevice_nameW;
 
-    TRACE("(%p)\n");
+    TRACE("(%p)\n", DriverObject);
 
     free_cache();
 


### PR DESCRIPTION
Addendum to ed7713bfa7b07e44c772dbf3d8f97d6dcbef4135.