### PR TITLE
mkbtrfs.vcxproj: upgrade WindowsTargetPlatformVersion to 10.0

### DIFF
--- a/mkbtrfs.vcxproj
+++ b/mkbtrfs.vcxproj
@@ -22,7 +22,7 @@
     <ProjectGuid>{2518533B-5F76-4B31-B906-7BFD15C1379A}</ProjectGuid>
     <RootNamespace>mkbtrfs</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">


### PR DESCRIPTION
Same/similar version as the 3 other projects.
Fix Visual Studio error MSB8036 when 8.1 is not installed.

--

Case = AppVeyor CI, Visual Studio 2019 image:
`C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Microsoft\VC\v160\Microsoft.Cpp.WindowsSDK.targets(46,5): error MSB8036: The Windows SDK version 8.1 was not found. Install the required version of Windows SDK or change the SDK version in the project property pages or by right-clicking the solution and selecting "Retarget solution". [...\mkbtrfs.vcxproj]`