### PR TITLE
write_roots: Fix a Visual Studio warning C4267 on x64

### DIFF
--- a/src/ubtrfs/ubtrfs.c
+++ b/src/ubtrfs/ubtrfs.c
@@ -609,7 +609,7 @@ static NTSTATUS write_roots(HANDLE h, LIST_ENTRY* roots, uint32_t node_size, BTR
                 dp -= item->size;
                 memcpy(dp, item->data, item->size);
 
-                ln->offset = dp - tree - sizeof(tree_header);
+                ln->offset = (uint32_t)(dp - tree - sizeof(tree_header));
             } else
                 ln->offset = 0;
 


### PR DESCRIPTION
No behavior change, only a bit better code.

--

At least, VS2015, VS2017 and VS2019, as installed on AppVeyor CI:
`...\src\ubtrfs\ubtrfs.c(612,61): warning C4267: '=': conversion from 'size_t' to 'uint32_t', possible loss of data [...\ubtrfs.vcxproj]`

`sizeof()` returns a `size_t`, so it is pretty obvious anyway.
