### PR TITLE
btrfs.vcxproj: Fix a Visual Studio warning LNK4281 on x64

### DIFF
--- a/btrfs.vcxproj
+++ b/btrfs.vcxproj
@@ -176,7 +176,6 @@
       <SubSystem>Native</SubSystem>
       <Driver>Driver</Driver>
       <EntryPointSymbol>DriverEntry</EntryPointSymbol>
-      <BaseAddress>0x10000</BaseAddress>
       <RandomizedBaseAddress />
       <DataExecutionPrevention />
       <TargetMachine>MachineX64</TargetMachine>
@@ -245,7 +244,6 @@
       <OptimizeReferences>true</OptimizeReferences>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <EntryPointSymbol>DriverEntry</EntryPointSymbol>
-      <BaseAddress>0x10000</BaseAddress>
       <RandomizedBaseAddress />
       <DataExecutionPrevention />
       <TargetMachine>MachineX64</TargetMachine>


### PR DESCRIPTION
Let use default dynamic setting.

Please, test driver on a x64 platform(s), which I do not have. Thanks.

--

At least, VS2017 and VS2019, as installed on AppVeyor CI:
`LINK : warning LNK4281: undesirable base address 0x10000 for x64 image; set base address above 4GB for best ASLR optimization [...\btrfs.vcxproj]`
