### PR TITLE
shellext/: add a workaround for compilers without C++17 Standard support

### DIFF
--- a/src/shellext/mountmgr.h
+++ b/src/shellext/mountmgr.h
@@ -1,9 +1,17 @@
 #pragma once
 
+// Workaround for compilers without C++17 Standard support.
+// #define NO_CPP17
+
 #include <vector>
 #include <string>
 #include <sstream>
+#ifndef NO_CPP17
 #include <string_view>
+#else
+#define string_view string
+#define wstring_view wstring
+#endif
 #include <iostream>
 #include <iomanip>
 

--- a/src/shellext/shellext.h
+++ b/src/shellext/shellext.h
@@ -23,9 +23,16 @@
 #define WINVER 0x0A00 // Windows 10
 #define _WIN32_WINNT 0x0A00
 
+// Workaround for compilers without C++17 Standard support.
+// #define NO_CPP17
+
 #include <windows.h>
 #include <winternl.h>
 #include <string>
+#ifdef NO_CPP17
+#define string_view string
+#define wstring_view wstring
+#endif
 #include <vector>
 #include <stdint.h>
 #include "../btrfs.h"


### PR DESCRIPTION
Fix building with MSVC <= 2015 (Toolset v140).
That should apply to GCC < 7.1(!?) too, for example.

At first glance, it seems to work fine on ReactOS.
I can't test on Windows: please, double-check.