### PR TITLE
fcb_get_sd and get_top_level_sd: fix error handling

### DIFF
--- a/src/fsctl.c
+++ b/src/fsctl.c
@@ -3885,7 +3885,7 @@ static NTSTATUS mknod(device_extension* Vcb, PFILE_OBJECT FileObject, void* data
 
     SeCaptureSubjectContext(&subjcont);
 
-    Status = SeAssignSecurityEx(parfileref ? parfileref->fcb->sd : NULL, NULL, (void**)&fcb->sd, NULL, fcb->type == BTRFS_TYPE_DIRECTORY,
+    Status = SeAssignSecurityEx(parfileref ? parfileref->fcb->sd : NULL, NULL, &fcb->sd, NULL, fcb->type == BTRFS_TYPE_DIRECTORY,
                                 SEF_SACL_AUTO_INHERIT, &subjcont, IoGetFileObjectGenericMapping(), PagedPool);
 
     if (!NT_SUCCESS(Status)) {

--- a/src/security.c
+++ b/src/security.c
@@ -519,7 +519,7 @@ void fcb_get_sd(fcb* fcb, struct _fcb* parent, bool look_for_xattr, PIRP Irp) {
 
     SeCaptureSubjectContext(&subjcont);
 
-    Status = SeAssignSecurityEx(parent->sd, NULL, (void**)&sd, NULL, fcb->type == BTRFS_TYPE_DIRECTORY, SEF_DACL_AUTO_INHERIT,
+    Status = SeAssignSecurityEx(parent->sd, NULL, &sd, NULL, fcb->type == BTRFS_TYPE_DIRECTORY, SEF_DACL_AUTO_INHERIT,
                                 &subjcont, IoGetFileObjectGenericMapping(), PagedPool);
     if (!NT_SUCCESS(Status)) {
         ERR("SeAssignSecurityEx returned %08x\n", Status);
@@ -921,9 +921,8 @@ NTSTATUS fcb_get_new_sd(fcb* fcb, file_ref* parfileref, ACCESS_STATE* as) {
     PSID owner;
     BOOLEAN defaulted;
 
-    Status = SeAssignSecurityEx(parfileref ? parfileref->fcb->sd : NULL, as->SecurityDescriptor, (void**)&fcb->sd, NULL, fcb->type == BTRFS_TYPE_DIRECTORY,
+    Status = SeAssignSecurityEx(parfileref ? parfileref->fcb->sd : NULL, as->SecurityDescriptor, &fcb->sd, NULL, fcb->type == BTRFS_TYPE_DIRECTORY,
                                 SEF_SACL_AUTO_INHERIT, &as->SubjectSecurityContext, IoGetFileObjectGenericMapping(), PagedPool);
-
     if (!NT_SUCCESS(Status)) {
         ERR("SeAssignSecurityEx returned %08x\n", Status);
         return Status;


### PR DESCRIPTION
In case of error, this PR should avoid partial data and memory leaks, and even a crash.

Please, double-check new logic.