### PR TITLE
Fix pool memory disclosure in drv_query_volume_information

### DIFF
--- a/src/btrfs.c
+++ b/src/btrfs.c
@@ -972,6 +972,8 @@ static NTSTATUS __stdcall drv_query_volume_information(_In_ PDEVICE_OBJECT Devic
 
     Status = STATUS_NOT_IMPLEMENTED;
 
+    RtlZeroMemory(Irp->AssociatedIrp.SystemBuffer, IrpSp->Parameters.QueryVolume.Length);
+
     switch (IrpSp->Parameters.QueryVolume.FsInformationClass) {
         case FileFsAttributeInformation:
         {
@@ -1066,7 +1068,6 @@ static NTSTATUS __stdcall drv_query_volume_information(_In_ PDEVICE_OBJECT Devic
             TRACE("FileFsObjectIdInformation\n");
 
             RtlCopyMemory(ffoi->ObjectId, &Vcb->superblock.uuid.uuid[0], sizeof(UCHAR) * 16);
-            RtlZeroMemory(ffoi->ExtendedInfo, sizeof(ffoi->ExtendedInfo));
 
             BytesCopied = sizeof(FILE_FS_OBJECTID_INFORMATION);
             Status = STATUS_SUCCESS;


### PR DESCRIPTION
In x86 build, the structure `_FILE_FS_VOLUME_INFORMATION`

```
kd> dt _FIlE_FS_VOLUME_INFORMATION
shell32!_FILE_FS_VOLUME_INFORMATION
   +0x000 VolumeCreationTime : _LARGE_INTEGER
   +0x008 VolumeSerialNumber : Uint4B
   +0x00c VolumeLabelLength : Uint4B
   +0x010 SupportsObjects  : UChar
   +0x012 VolumeLabel      : [1] Wchar
```

is added 1 padding byte after the field `SupportsObjects` so it will lead to memory disclosure although all fields are initialized.

ReactOS is also affected by this bug, this is the report: https://github.com/reactos/reactos/pull/2975