### PR TITLE
Fix pool memory disclosure in set_basic_information

### DIFF
--- a/src/fileinfo.c
+++ b/src/fileinfo.c
@@ -156,6 +156,8 @@ static NTSTATUS set_basic_information(device_extension* Vcb, PIRP Irp, PFILE_OBJ
     bool inode_item_changed = false;
     NTSTATUS Status;
 
+    RtlZeroMemory(fbi, sizeof(FILE_BASIC_INFORMATION));
+
     if (fcb->ads) {
         if (fileref && fileref->parent)
             fcb = fileref->parent->fcb;


### PR DESCRIPTION
In x86 build, the structure `FILE_BASIC_INFORMATION` are added 4 padding bytes after field `FileAttributes` so `sizeof(FILE_BASIC_INFORMATION)` is 0x28, not 0x24. It could lead to memory disclsoure.

```
kd> dt FILE_BASIC_INFORMATION
nt!FILE_BASIC_INFORMATION
   +0x000 CreationTime     : _LARGE_INTEGER
   +0x008 LastAccessTime   : _LARGE_INTEGER
   +0x010 LastWriteTime    : _LARGE_INTEGER
   +0x018 ChangeTime       : _LARGE_INTEGER
   +0x020 FileAttributes   : Uint4B
kd> ??sizeof(FILE_BASIC_INFORMATION)
unsigned int 0x28
```

ReactOS is also affected by this bug. https://github.com/reactos/reactos/pull/2926