### PR TITLE
vol_query_device_name: check if called on file/subdir

### DIFF
--- a/src/volume.c
+++ b/src/volume.c
@@ -307,6 +307,10 @@ static NTSTATUS vol_query_device_name(volume_device_extension* vde, PIRP Irp) {
     PIO_STACK_LOCATION IrpSp = IoGetCurrentIrpStackLocation(Irp);
     PMOUNTDEV_NAME name;
 
+    if (IrpSp->FileObject && IrpSp->FileObject->FsContext) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
     if (IrpSp->Parameters.DeviceIoControl.OutputBufferLength < sizeof(MOUNTDEV_NAME)) {
         Irp->IoStatus.Information = sizeof(MOUNTDEV_NAME);
         return STATUS_BUFFER_TOO_SMALL;


### PR DESCRIPTION
Fixes #358

This makes it match NTFS behaviour, but I'm not completely sure if this is the proper implementation.