### PR TITLE
query_directory: stop if specific file already found

### DIFF
--- a/src/dirctrl.c
+++ b/src/dirctrl.c
@@ -832,6 +832,8 @@ static NTSTATUS query_directory(PIRP Irp) {
             if (FsRtlDoesNameContainWildCards(IrpSp->Parameters.QueryDirectory.FileName)) {
                 has_wildcard = true;
                 specific_file = false;
+            } else if (!initial) {
+                return STATUS_NO_MORE_FILES;
             }
         }
 


### PR DESCRIPTION
Fixes the specific issue in https://github.com/maharmstone/btrfs/issues/65#issuecomment-811685014.

MO2 (or more specifically, [usvfs](https://github.com/ModOrganizer2/usvfs)) seems to loop until `NtQueryDirectoryFile` returns `STATUS_SUCCESS`, even when the filename has no wildcards. This made it run at `O(n^2)` instead of `O(n)`.