### PR TITLE
CMakeLists.txt: fix mingw-w64 include path for DDK-related headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ add_library(btrfs SHARED ${SRC_FILES})
 if(MSVC)
     include_directories("$ENV{WindowsSdkDir}Include\\$ENV{WindowsSDKLibVersion}km")
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND WIN32)
-    include_directories("${CMAKE_FIND_ROOT_PATH}/usr/include/ddk")
+    include_directories("${CMAKE_FIND_ROOT_PATH}/include/ddk")
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")


### PR DESCRIPTION
In my Linux distros (Manjaro Linux and Ubuntu 18.04), the DDK-related files are placed in `/usr/i686-w64-mingw32/include/ddk` for 32-bit, and `/usr/x86_64-w64-mingw32/include/ddk` for 64-bit.

Right now there's an excess `/usr` in the `include_directories` for DDK-related stuffs, which prevents the compiler from finding the correct header files.

Additionally, to cross-compile for 32-bit, I need to also revert commit 9ab86ba3d2f72d7d82e16392d99dc93ae8bae9d8. I need some clarifications about "multilib compiler" as it doesn't seem to work for my Linux distros and I still have to actually point to the `i686` paths for now.

At least `shellbtrfs` and `mkbtrfs` can be built with mingw-w64 from Linux at the moment (see #378). `ubtrfs` and `btrfs` can't be built yet as mingw-w64 doesn't have the `ata.h` header.