### PR TITLE
Added minimal CI + Signing section

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
     - name: Get Sources
       uses: actions/checkout@v3
       
-    - uses: ilammy/msvc-dev-cmd@v1
+    - name: Setup shell
+      uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: ${{ matrix.shell_arch }}
     
@@ -73,3 +74,51 @@ jobs:
       with:
         name: btrfs-pdb
         path: upload-pdb/*
+
+  sign:
+    needs: build
+    runs-on: windows-latest
+    name: Sign
+
+    env:
+      INF2CAT_PROGRAM: 'C:/Program Files (x86)/Windows Kits/10/bin/x86/Inf2Cat.exe'
+
+    steps:
+      - name: Get Sources
+        uses: actions/checkout@v3
+
+      - name: Setup shell
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x86
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: btrfs
+          path: upload
+
+      - name: Import key
+        run: |
+          # Create the PFX file from the base64-encoded secret
+          "${{ secrets.PFX_FILE_B64 }}" | Out-File -FilePath pfx.b64
+          CertUtil -decode pfx.b64 cert.pfx
+          # Import it
+          $plaintextpwd = "password"
+          $pwd = ConvertTo-SecureString -String $plaintextpwd -Force -AsPlainText
+          Import-PfxCertificate -FilePath ./cert.pfx -CertStoreLocation Cert:\CurrentUser\My -Password $pwd
+
+      - name: Create catalog file
+        run: |
+          cd upload
+          & "${{env.INF2CAT_PROGRAM}}" /os:10_NI_X64 /driver:.
+      
+      - name: Sign catalog file
+        run: |
+          cd upload
+          SignTool sign /fd SHA256 /v /s My /n "Btrfs driver" /t http://timestamp.digicert.com btrfs.cat
+
+      - name: Upload driver
+        uses: actions/upload-artifact@v3
+        with:
+          name: btrfs
+          path: upload/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
       
     - name: Prepare files for upload
       run: |
-      
         mkdir upload
         mkdir upload/${{ matrix.win_arch }}
 
@@ -53,7 +52,6 @@ jobs:
         copy build/shellbtrfs.dll upload/${{ matrix.win_arch }}
         copy build/mkbtrfs.exe upload/${{ matrix.win_arch }}
         copy build/btrfs.sys upload/${{ matrix.win_arch }}
-
 
         mkdir upload-pdb
         mkdir upload-pdb/${{ matrix.win_arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,20 +12,19 @@ env:
 
 jobs:
   build:
-  
     strategy:
       matrix:
         include:
-          - arch: x64
-            folder: x64
-          - arch: x86
-            folder: x86
-          - arch: amd64_arm64
-            folder: aarch64
-          - arch: amd64_arm
-            folder: arm
+          - shell_arch: x64
+            win_arch: x64
+          - shell_arch: x86
+            win_arch: x86
+          - shell_arch: amd64_arm64
+            win_arch: arm64
+          - shell_arch: amd64_arm
+            win_arch: arm
 
-    name: Build for ${{ matrix.folder }}
+    name: Build for ${{ matrix.win_arch }}
     runs-on: windows-latest
 
     steps:
@@ -34,7 +33,7 @@ jobs:
       
     - uses: ilammy/msvc-dev-cmd@v1
       with:
-        arch: ${{ matrix.arch }}
+        arch: ${{ matrix.shell_arch }}
     
     - name: Prepare build
       run: cmake -B build -G "Ninja"
@@ -46,22 +45,22 @@ jobs:
       run: |
       
         mkdir upload
-        mkdir upload\${{ matrix.folder }}
+        mkdir upload/${{ matrix.win_arch }}
 
         copy src/btrfs.inf upload
-        copy build\ubtrfs.dll upload\${{ matrix.folder }}
-        copy build\shellbtrfs.dll upload\${{ matrix.folder }}
-        copy build\mkbtrfs.exe upload\${{ matrix.folder }}
-        copy build\btrfs.sys upload\${{ matrix.folder }}
+        copy build/ubtrfs.dll upload/${{ matrix.win_arch }}
+        copy build/shellbtrfs.dll upload/${{ matrix.win_arch }}
+        copy build/mkbtrfs.exe upload/${{ matrix.win_arch }}
+        copy build/btrfs.sys upload/${{ matrix.win_arch }}
 
 
         mkdir upload-pdb
-        mkdir upload-pdb\${{ matrix.folder }}
+        mkdir upload-pdb/${{ matrix.win_arch }}
 
-        copy build\ubtrfs.pdb upload-pdb\${{ matrix.folder }}
-        copy build\shellbtrfs.pdb upload-pdb\${{ matrix.folder }}
-        copy build\mkbtrfs.pdb upload-pdb\${{ matrix.folder }}
-        copy build\btrfs.pdb upload-pdb\${{ matrix.folder }}
+        copy build/ubtrfs.pdb upload-pdb/${{ matrix.win_arch }}
+        copy build/shellbtrfs.pdb upload-pdb/${{ matrix.win_arch }}
+        copy build/mkbtrfs.pdb upload-pdb/${{ matrix.win_arch }}
+        copy build/btrfs.pdb upload-pdb/${{ matrix.win_arch }}
 
     - name: Upload driver files
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+name: Build CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+    branches: ["*"]
+  workflow_dispatch:
+
+env:
+  BUILD_CONFIG: RelWithDebInfo
+
+jobs:
+  build:
+  
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            folder: x64
+          - arch: x86
+            folder: x86
+          - arch: amd64_arm64
+            folder: aarch64
+          - arch: amd64_arm
+            folder: arm
+
+    name: Build for ${{ matrix.folder }}
+    runs-on: windows-latest
+
+    steps:
+    - name: Get Sources
+      uses: actions/checkout@v3
+      
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: ${{ matrix.arch }}
+    
+    - name: Prepare build
+      run: cmake -B build -G "Ninja"
+      
+    - name: Build
+      run: cmake --build build --config ${{env.BUILD_CONFIG}} -j 3
+      
+    - name: Prepare files for upload
+      run: |
+      
+        mkdir upload
+        mkdir upload\${{ matrix.folder }}
+
+        copy src/btrfs.inf upload
+        copy build\ubtrfs.dll upload\${{ matrix.folder }}
+        copy build\shellbtrfs.dll upload\${{ matrix.folder }}
+        copy build\mkbtrfs.exe upload\${{ matrix.folder }}
+        copy build\btrfs.sys upload\${{ matrix.folder }}
+
+
+        mkdir upload-pdb
+        mkdir upload-pdb\${{ matrix.folder }}
+
+        copy build\ubtrfs.pdb upload-pdb\${{ matrix.folder }}
+        copy build\shellbtrfs.pdb upload-pdb\${{ matrix.folder }}
+        copy build\mkbtrfs.pdb upload-pdb\${{ matrix.folder }}
+        copy build\btrfs.pdb upload-pdb\${{ matrix.folder }}
+
+    - name: Upload driver files
+      uses: actions/upload-artifact@v3
+      with:
+        name: btrfs
+        path: upload/*
+
+    - name: Upload PDB files
+      uses: actions/upload-artifact@v3
+      with:
+        name: btrfs-pdb
+        path: upload-pdb/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+out
+.vs
+build
+build-*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <a title="'Build' workflow Status" href="https://github.com/maharmstone/btrfs/actions?query=workflow%3ABuild%20CI"><img alt="'Build workflow Status" src="https://img.shields.io/github/workflow/status/maharmstone/btrfs/Build%20CI?longCache=true&style=for-the-badge&label=Build&logoColor=fff&logo=GitHub%20Actions"></a>
+</p> 
+
 WinBtrfs v1.8
 -------------
 

--- a/README.md
+++ b/README.md
@@ -146,16 +146,46 @@ generate your Makefile.
 
 Signing
 -----------
-
 To install a built-from-source or a nightly (from github actions) driver, you need to sign it
-In this section, I will show how to compile the driver using test-signing.
+In this section, I will show how to disable driver signature enforcement, or how to sign the driver using test-signing
+Warning : both of these solutions aren't perfect, if you are looking for a everyday-use it is recommanded to use the release builds, which are signed with a Microsoft-trusted key.
+
+
+## Disabling signature enforcement
+Note : this isn't persistent accross reboots
+
+Relevant link : https://docs.microsoft.com/en-us/windows-hardware/drivers/install/installing-an-unsigned-driver-during-development-and-test
+
+### 1 - Reboot your computer without driver signature enforcement
+
+(This can be done by pressing the 'Shift' key while rebooting the computer, this will take you to a special screen from which you can select "Troubleshoot" -> "Startup settings" -> "Disable driver signature enforcement")
+
+### 2 - Install the driver
+
+Open the previously downloaded artifact from Github Actions (or mimic the directory structure and fill it with the binaries you just compiled), right-click the btrfs.inf file -> install
+
+A window saying "Microsoft can't verify the publisher of this driver" should pop-up. Click "Install anyway"
+
+If the window didn't show up, the driver probably wasn't installed, make sure you booted your computer with driver signature enforcement disabled.
+
+The computer should next tell you to reboot your computer
+
+### 3 - Reboot the computer again without driver signature enforcement
+Follow the same instructions as step 1
+
+### 4 - Done !
+The driver should now be installed ! Note it will only load when the computer is started without driver signature enforcement
+
+
+
+## Test-signing the driver
+Note : This method is harder to put in place, and has the only benefit of persisting after reboots.
+
 Example commands are given for each steps but it is recommand to check the microsoft documentation link about test-signing, so you know what you are doing
 
-More information can be found at https://docs.microsoft.com/en-us/windows-hardware/drivers/install/test-signing
+Relevant link : https://docs.microsoft.com/en-us/windows-hardware/drivers/install/test-signing
 
-Note : this is not practical for a everyday use
-
-**1 - Put your computer in test mode**
+### 1 - Put your computer in test mode
 
 test-signing doesn't seem to work with Windows by default. You will need to put your computer in a special mode to allow test-signing.
 
@@ -163,22 +193,22 @@ test-signing doesn't seem to work with Windows by default. You will need to put 
 
 Note : you might need to disable Secure Boot for this to work
 
-**2 - Generate a MakeCert certificate**
+### 2 - Generate a MakeCert certificate
 
 This certificate will be used to sign the catalog file of the driver
 
 `makecert -r -pe -ss PrivateCertStore -n CN=Contoso.com(Test) ContosoTest.cer`
 
-**3 - Install the certificate to your system**
+### 3 - Install the certificate to your system
 
 For your certificate to be effective, it needs to be installed in the "Trusted Root Certification Authorities" certificate store of the computer you want to install the driver on.
 You can add it by launching "CertMgr" **as administrator**, selecting the "Trusted Root Certification Authorities" certificate store, and importing the .cer file generated earlier
 (The command given on the documentation doesn't seem to work and just launches the CertMgr GUI)
 
-**4 - Generate a catalog file for your driver**
+### 4 - Generate a catalog file for your driver
 
 You will need the "Inf2Cat" tool, installed as part of the WDK.
-Run the command in the same directory as your .inf file (or modify the /driver flag)
+Run the command in the same directory as your btrfs.inf file (or modify the /driver flag)
 
 The command will differ in your case (because of the path) but here is the one I used :
 
@@ -186,7 +216,7 @@ The command will differ in your case (because of the path) but here is the one I
 
 Note : this was tested in Windows 11, you might need to change the values of the /os flag according to your Windows version
 
-**5 - Sign the catalog file**
+### 5 - Sign the catalog file
 
 Simply sign the catalog file of the driver with the certificate you generated
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Compilation
 
 To compile with Visual C++ 2019, open the directory and let CMake do its thing.
 If you have the Windows DDK installed correctly, it should just work.
-Note : you need to use the Ninja generator for CMake, else the driver might not work once installed
+Note: you need to use the Ninja generator for CMake, else the driver might not work once installed
 
 To compile with GCC on Linux, you will need a cross-compiler set up, for either
 `i686-w64-mingw32` or `x86_64-w64-mingw32`. Create a build directory, then use
@@ -150,13 +150,15 @@ generate your Makefile.
 
 Signing
 -----------
-To install a built-from-source or a nightly (from github actions) driver, you need to sign it
-In this section, I will show how to disable driver signature enforcement, or how to sign the driver using test-signing
-Warning : both of these solutions aren't perfect, if you are looking for a everyday-use it is recommanded to use the release builds, which are signed with a Microsoft-trusted key.
+
+To install a built-from-source or a nightly (from github actions) driver, you need to sign it.
+In this section, I will show how to disable driver signature enforcement, or how to sign the driver using test-signing.
+Warning: both of these solutions aren't perfect, if you are looking for a everyday-use it is recommanded to use the release builds, which are signed with a Microsoft-trusted key.
 
 
 ## Disabling signature enforcement
-Note : this isn't persistent accross reboots
+
+Note: this isn't persistent accross reboots
 
 Relevant link : https://docs.microsoft.com/en-us/windows-hardware/drivers/install/installing-an-unsigned-driver-during-development-and-test
 
@@ -175,19 +177,22 @@ If the window didn't show up, the driver probably wasn't installed, make sure yo
 The computer should next tell you to reboot your computer
 
 ### 3 - Reboot the computer again without driver signature enforcement
+
 Follow the same instructions as step 1
 
 ### 4 - Done !
+
 The driver should now be installed ! Note it will only load when the computer is started without driver signature enforcement
 
 
 
 ## Test-signing the driver
-Note : This method is harder to put in place, and has the only benefit of persisting after reboots.
+
+Note: This method is harder to put in place, and has the only benefit of persisting after reboots.
 
 Example commands are given for each steps but it is recommand to check the microsoft documentation link about test-signing, so you know what you are doing
 
-Relevant link : https://docs.microsoft.com/en-us/windows-hardware/drivers/install/test-signing
+Relevant link: https://docs.microsoft.com/en-us/windows-hardware/drivers/install/test-signing
 
 ### 1 - Put your computer in test mode
 
@@ -195,7 +200,7 @@ test-signing doesn't seem to work with Windows by default. You will need to put 
 
 `bcdedit  /set  testsigning  on`
 
-Note : you might need to disable Secure Boot for this to work
+Note: you might need to disable Secure Boot for this to work
 
 ### 2 - Generate a MakeCert certificate
 
@@ -218,7 +223,7 @@ The command will differ in your case (because of the path) but here is the one I
 
 `"C:\Program Files (x86)\Windows Kits\10\bin\x86\Inf2Cat.exe" /os:10_NI_X64 /driver:.`
 
-Note : this was tested in Windows 11, you might need to change the values of the /os flag according to your Windows version
+Note: this was tested in Windows 11, you might need to change the values of the /os flag according to your Windows version
 
 ### 5 - Sign the catalog file
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<p align="center">
-  <a title="'Build' workflow Status" href="https://github.com/maharmstone/btrfs/actions?query=workflow%3ABuild%20CI"><img alt="'Build workflow Status" src="https://img.shields.io/github/workflow/status/maharmstone/btrfs/Build%20CI?longCache=true&style=for-the-badge&label=Build&logoColor=fff&logo=GitHub%20Actions"></a>
-</p> 
+[![Build CI](https://github.com/maharmstone/btrfs/actions/workflows/build.yml/badge.svg)](https://github.com/maharmstone/btrfs/actions/workflows/build.yml)
 
 WinBtrfs v1.8
 -------------

--- a/README.md
+++ b/README.md
@@ -144,6 +144,56 @@ To compile with GCC on Linux, you will need a cross-compiler set up, for either
 either `mingw-x86.cmake` or `mingw-amd64.cmake` as CMake toolchain files to
 generate your Makefile.
 
+Signing
+-----------
+
+To install a built-from-source or a nightly (from github actions) driver, you need to sign it
+In this section, I will show how to compile the driver using test-signing.
+Example commands are given for each steps but it is recommand to check the microsoft documentation link about test-signing, so you know what you are doing
+
+More information can be found at https://docs.microsoft.com/en-us/windows-hardware/drivers/install/test-signing
+
+Note : this is not practical for a everyday use
+
+**1 - Put your computer in test mode**
+
+test-signing doesn't seem to work with Windows by default. You will need to put your computer in a special mode to allow test-signing.
+
+`bcdedit  /set  testsigning  on`
+
+Note : you might need to disable Secure Boot for this to work
+
+**2 - Generate a MakeCert certificate**
+
+This certificate will be used to sign the catalog file of the driver
+
+`makecert -r -pe -ss PrivateCertStore -n CN=Contoso.com(Test) ContosoTest.cer`
+
+**3 - Install the certificate to your system**
+
+For your certificate to be effective, it needs to be installed in the "Trusted Root Certification Authorities" certificate store of the computer you want to install the driver on.
+You can add it by launching "CertMgr" **as administrator**, selecting the "Trusted Root Certification Authorities" certificate store, and importing the .cer file generated earlier
+(The command given on the documentation doesn't seem to work and just launches the CertMgr GUI)
+
+**4 - Generate a catalog file for your driver**
+
+You will need the "Inf2Cat" tool, installed as part of the WDK.
+Run the command in the same directory as your .inf file (or modify the /driver flag)
+
+The command will differ in your case (because of the path) but here is the one I used :
+
+`"C:\Program Files (x86)\Windows Kits\10\bin\x86\Inf2Cat.exe" /os:10_NI_X64 /driver:.`
+
+Note : this was tested in Windows 11, you might need to change the values of the /os flag according to your Windows version
+
+**5 - Sign the catalog file**
+
+Simply sign the catalog file of the driver with the certificate you generated
+
+`SignTool sign /fd SHA256 /v /s PrivateCertStore /n contoso.com(test) /t http://timestamp.digicert.com btrfs.cat`
+
+Only steps 4-5 needs to be done again to sign a new build of the driver
+
 Mappings
 --------
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Compilation
 
 To compile with Visual C++ 2019, open the directory and let CMake do its thing.
 If you have the Windows DDK installed correctly, it should just work.
+Note : you need to use the Ninja generator for CMake, else the driver might not work once installed
 
 To compile with GCC on Linux, you will need a cross-compiler set up, for either
 `i686-w64-mingw32` or `x86_64-w64-mingw32`. Create a build directory, then use

--- a/src/btrfs.inf
+++ b/src/btrfs.inf
@@ -113,7 +113,7 @@ mkbtrfs.exe = 1,,
 1 = %DiskId1%,,,\arm
 
 [SourceDisksNames.arm64]
-1 = %DiskId1%,,,\aarch64
+1 = %DiskId1%,,,\arm64
 
 ;;
 ;; String Section


### PR DESCRIPTION
Hey, following what I said in #499, I made a minimal CI setup
you can check https://github.com/iTrooz/btrfs/actions/runs/2748809550 for an example run

Unfortunately, I couldn't test the binaries because I didn't understand how to sign the driver

A few questions :

Do you want the CI to automatically sign the driver ? From what I understand, drivers have to be signed by a Microsoft-trusted CA, so I guess you have a key with such trust.
It could be added as a secret in the CI (See Settings -> Secrets -> Actions ) so the CI can use the key to sign the driver while keeping it secure.
This would allow people to test nightly versions of the driver (to test if their issue was resolved for example) without going through the hassle of signing it themselves

In case you do not want to add the key to the CI :
- Could you add a "Signing" section after "Compilation", so that people know how to sign the driver for test purposes ?
- Do you think it's still useful for the CI to compile/output artifacts for all targeted architectures ? I guess just compiling for x64 to test that it works would suffice


I understand that you did not agree for such a feature and that you may refuse it, I only worked on it because I had some free time and wanted to learn how to compile the driver