### PR TITLE
fixed macro redefinition warnings

### DIFF
--- a/src/tests/test.h
+++ b/src/tests/test.h
@@ -17,17 +17,18 @@
 
 #pragma once
 
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <ntstatus.h>
+#define WIN32_NO_STATUS
 #include <windef.h>
 #include <winbase.h>
 #include <winternl.h>
 #include <devioctl.h>
 #include <ntdddisk.h>
-#include <stdio.h>
-#include <stdarg.h>
-#include <stdlib.h>
-#include <stdbool.h>
 #include <stringapiset.h>
-#include <ntstatus.h>
 #include <memory>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
I noticed a bunch of warnings about macro redefinition when building the driver.
It should be fixed with this

Btw (not sure where to ask), is there a reason why you merge the branches locally on your computer instead of accepting the pull request ?