### PR TITLE
Clarify setting mappings in registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ Mappings
 
 The user mappings are stored in the registry key
 HKLM\SYSTEM\CurrentControlSet\services\btrfs\Mappings. Create a DWORD with the
-name of your Windows SID (e.g. S-1-5-21-1379886684-2432464051-424789967-1001),
-and the value of your Linux uid (e.g. 1000). It will take effect next time the
+name of your Windows SID (e.g. S-1-5-21-1379886684-2432464051-424789967-1001), set the base to **decimal** (unless you like hexidecimal),
+and the value of your Linux uid (e.g. 1000 in decimal, or 3E8 in hexidecimal). It will take effect next time the
 driver is loaded.
 
 You can find your current SID by running `wmic useraccount get name,sid`.


### PR DESCRIPTION
New keys in the Windows registry by default use hexadecimal which might confuse some people later when their files are owned by `4096` instead of `1000` because they were not paying attention on the base they used.

---

Personally it confused me a bit and thought I didn't set the name or value correctly, but no I didn't pay attention to the base used. I figure updating the `README.md` would be a good idea so people do not get tripped up like I did.