### PR TITLE
shellext: fix GlobalUnlock() calls

### DIFF
--- a/src/shellext/contextmenu.h
+++ b/src/shellext/contextmenu.h
@@ -34,7 +34,6 @@ public:
 
     virtual ~BtrfsContextMenu() {
         if (stgm_set) {
-            GlobalUnlock(stgm.hGlobal);
             ReleaseStgMedium(&stgm);
         }
 

--- a/src/shellext/propsheet.h
+++ b/src/shellext/propsheet.h
@@ -118,7 +118,6 @@ public:
 
     virtual ~BtrfsPropSheet() {
         if (stgm_set) {
-            GlobalUnlock(stgm.hGlobal);
             ReleaseStgMedium(&stgm);
         }
 

--- a/src/shellext/volpropsheet.cpp
+++ b/src/shellext/volpropsheet.cpp
@@ -65,20 +65,19 @@ HRESULT __stdcall BtrfsVolPropSheet::Initialize(PCIDLIST_ABSOLUTE pidlFolder, ID
     if (FAILED(pdtobj->GetData(&format, &stgm)))
         return E_INVALIDARG;
 
-    stgm_set = true;
-
     hdrop = (HDROP)GlobalLock(stgm.hGlobal);
 
     if (!hdrop) {
         ReleaseStgMedium(&stgm);
-        stgm_set = false;
         return E_INVALIDARG;
     }
+
+    stgm_set = true;
 
     num_files = DragQueryFileW((HDROP)stgm.hGlobal, 0xFFFFFFFF, nullptr, 0);
 
     if (num_files > 1) {
-        GlobalUnlock(hdrop);
+        GlobalUnlock(stgm.hGlobal);
         return E_FAIL;
     }
 
@@ -109,7 +108,7 @@ HRESULT __stdcall BtrfsVolPropSheet::Initialize(PCIDLIST_ABSOLUTE pidlFolder, ID
 
                         i++;
                     } else {
-                        GlobalUnlock(hdrop);
+                        GlobalUnlock(stgm.hGlobal);
                         return E_FAIL;
                     }
                 } else
@@ -117,7 +116,7 @@ HRESULT __stdcall BtrfsVolPropSheet::Initialize(PCIDLIST_ABSOLUTE pidlFolder, ID
             }
 
             if (!NT_SUCCESS(Status)) {
-                GlobalUnlock(hdrop);
+                GlobalUnlock(stgm.hGlobal);
                 return E_FAIL;
             }
 
@@ -127,15 +126,15 @@ HRESULT __stdcall BtrfsVolPropSheet::Initialize(PCIDLIST_ABSOLUTE pidlFolder, ID
             ignore = false;
             balance = new BtrfsBalance(fn);
         } else {
-            GlobalUnlock(hdrop);
+            GlobalUnlock(stgm.hGlobal);
             return E_FAIL;
         }
     } else {
-        GlobalUnlock(hdrop);
+        GlobalUnlock(stgm.hGlobal);
         return E_FAIL;
     }
 
-    GlobalUnlock(hdrop);
+    GlobalUnlock(stgm.hGlobal);
 
     return S_OK;
 }

--- a/src/shellext/volpropsheet.h
+++ b/src/shellext/volpropsheet.h
@@ -40,7 +40,6 @@ public:
 
     virtual ~BtrfsVolPropSheet() {
         if (stgm_set) {
-            GlobalUnlock(stgm.hGlobal);
             ReleaseStgMedium(&stgm);
         }
 


### PR DESCRIPTION
`GlobalUnlock()`:
- Parameter is expected to be the same handle, not the returned pointer.
- Call from destructor did not match any lock call.
- Add 1 missing call.

`stgm_set`:
- Simplify setting it a bit.
- Add 2 checks before using `stgm.hGlobal`.