### PR TITLE
Document: Add a tip -- to prevent Btrfs driver loading during system booting

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ HKLM\SYSTEM\CurrentControlSet\services\btrfs\Start to 4, to disable the service.
 After you reboot, you can then delete the btrfs key and remove
 C:\Windows\System32\drivers\btrfs.sys.
 
+If you want to prevent Btrfs driver loading during system booting, for example you have to because of system BSOD(Blue or green screen, very quick after desktop appears.),
+please read this tip.
+
 Compilation
 -----------
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ HKLM\SYSTEM\CurrentControlSet\services\btrfs\Start to 4, to disable the service.
 After you reboot, you can then delete the btrfs key and remove
 C:\Windows\System32\drivers\btrfs.sys.
 
-If you want to prevent Btrfs driver loading during system booting, for example you have to because of system BSOD(Blue or green screen, very quick after desktop appears.),
+If you want to prevent Btrfs driver loading during system booting, 
+for example you have to because of system BSOD(Blue or green screen, very quick after desktop appears.),
 please read <a href="doc/Prevent driver loading in booting">this tip</a>. 
 
 Compilation

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ After you reboot, you can then delete the btrfs key and remove
 C:\Windows\System32\drivers\btrfs.sys.
 
 If you want to prevent Btrfs driver loading during system booting, for example you have to because of system BSOD(Blue or green screen, very quick after desktop appears.),
-please read this tip.
+please read <a href="doc/Prevent driver loading in booting">this tip</a>.
 
 Compilation
 -----------

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ After you reboot, you can then delete the btrfs key and remove
 C:\Windows\System32\drivers\btrfs.sys.
 
 If you want to prevent Btrfs driver loading during system booting, for example you have to because of system BSOD(Blue or green screen, very quick after desktop appears.),
-please read <a href="doc/Prevent driver loading in booting">this tip</a>.
+please read <a href="doc/Prevent driver loading in booting">this tip</a>. 
 
 Compilation
 -----------
@@ -283,6 +283,10 @@ uninstall Paragon, then re-enable automount by running `diskpart` and typing
 On very old versions of Windows (XP, Server 2003?), Windows ignores Linux partitions
 entirely. If this is the case for you, try running `fdisk` on Linux and changing your
 partition type from 83 to 7.
+
+* Windows system turns to show BSOD after every booting time! How to prevent Btrfs driver loading?
+
+please read <a href="doc/Prevent driver loading in booting">this tip</a>. 
 
 Changelog
 ---------

--- a/doc/Prevent driver loading in booting
+++ b/doc/Prevent driver loading in booting
@@ -32,4 +32,4 @@ Now, you can switch to regedit, press "sys", Alt+F, Alt+U, Alt+Y, to unmount the
 Now it is done preventing Btrfs driver loading in system booting.
 Restart the computer, switch to the target OS, then you can delete the btrfs key and remove C:\Windows\System32\drivers\btrfs.sys, unistalling the btrfs driver.
 
-(For more, there is more options for mounting. You can get in much farther down to get, #Mount options .)
+(For more, there is more options for mounting. You can get in much farther down to get, <a href="/README.me/#Mount>Mount</a> options .)

--- a/doc/Prevent driver loading in booting
+++ b/doc/Prevent driver loading in booting
@@ -1,0 +1,35 @@
+# Preventing Btrfs driver loading during system booting, or unistall Btrfs driver (in some cases) that causes (in some cases)  contained system BSOD.
+
+Maybe you want to unistall the driver without entering to the OS which installed it. 
+(Such as, there are errors in a Btrfs part. This can cause Windows BSOD, show blue or green screen, very quick after desktop appears-- at least on WinBtrfs v1.9.)
+(So, it is sometimes necessary to prevent Btrfs driver loading during system booting.)
+
+You can switch to another OS, open regedit as admin. (Of course avaible in Windows PE, or is it also avaible in Linux?) 
+Press win+r, then type "regedit", press Enter.
+
+Such as, load regedit of target OS to HKLM(HKEY_LOCAL_MACHINE) as name "sys", and it is in part P, as I did.
+(Switch to regedit.) Press HKLM, Alt+F, Alt+L （to load configuration unit), then switch folder directory to "P:\Windows\System32\config\", find and choose the file "system".
+(P:\Windows\System32\config\system)
+(If your target system is in other part, please change part letter to yours. Such as, P:\Windows\System32\config\ -> D:\Windows\System32\config\ .)
+(But do this before, please make sure mount the part including the target OS as read-write able. Such as you need to care about, the OS is in VHD/VHDX, is as RAMOS or ghost/shadow OS.)
+Name it as "sys".(Need, or you need to modify the text copied from below.)
+
+Now, copy five lines below to an empty text(notepad) file, and save it as an reg file(such as"Btrfs_driver-stop.reg")(ANSI encoding method is ok.).
+
+---
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\sys\ControlSet001\Services\btrfs]
+"Start"=dword:00000004
+
+---
+
+Double click the file, press Alt+Y, to continue import it to regedit.
+
+Now, you can switch to regedit, press "sys", Alt+F, Alt+U, Alt+Y, to unmount the regedit "system" of target OS. 
+(Remember to unmount VHD/VHDX if it exists. ) 
+
+Now it is done preventing Btrfs driver loading in system booting.
+Restart the computer, switch to the target OS, then you can delete the btrfs key and remove C:\Windows\System32\drivers\btrfs.sys, unistalling the btrfs driver.
+
+(For more, there is more options for mounting. You can get in much farther down to get, #Mount options .)

--- a/doc/Prevent driver loading in booting
+++ b/doc/Prevent driver loading in booting
@@ -32,4 +32,5 @@ Now, you can switch to regedit, press "sys", Alt+F, Alt+U, Alt+Y, to unmount the
 Now it is done preventing Btrfs driver loading in system booting.
 Restart the computer, switch to the target OS, then you can delete the btrfs key and remove C:\Windows\System32\drivers\btrfs.sys, unistalling the btrfs driver.
 
-(For more, there is more options for mounting. You can get in much farther down to get, <a href="/README.me/#Mount">Mount</a> options .)
+(For more, there is more options for mounting. You can get in much farther down to get, <a href="/README.md#Mount">Mount</a> options .)
+

--- a/doc/Prevent driver loading in booting
+++ b/doc/Prevent driver loading in booting
@@ -32,4 +32,4 @@ Now, you can switch to regedit, press "sys", Alt+F, Alt+U, Alt+Y, to unmount the
 Now it is done preventing Btrfs driver loading in system booting.
 Restart the computer, switch to the target OS, then you can delete the btrfs key and remove C:\Windows\System32\drivers\btrfs.sys, unistalling the btrfs driver.
 
-(For more, there is more options for mounting. You can get in much farther down to get, <a href="/README.me/#Mount>Mount</a> options .)
+(For more, there is more options for mounting. You can get in much farther down to get, <a href="/README.me/#Mount">Mount</a> options .)


### PR DESCRIPTION
Preventing Btrfs driver loading during system booting, or unistall Btrfs driver (in some cases) that causes (in some cases)  contained system BSOD.

Maybe you want to unistall the driver without entering to the OS which installed it.
(Such as, there are errors in a Btrfs part. This can cause Windows BSOD, show blue or green screen, very quick after desktop appears-- at least on WinBtrfs v1.9.)
(So, it is sometimes necessary to prevent Btrfs driver loading during system booting.)

It is able to done this.
Switch to another system(PE modified by third party is OK.), use regedit  and edit. 
This can prevent Btrfs driver loading, solve the problem. 

(This is my first time using Github to make file, edit and pull request. Welcome taught.)
