### PR TITLE
implement acquire/release for ccflush

### DIFF
--- a/src/fastio.c
+++ b/src/fastio.c
@@ -323,8 +323,19 @@ static NTSTATUS __stdcall fast_io_release_for_mod_write(PFILE_OBJECT FileObject,
 
 _Function_class_(FAST_IO_ACQUIRE_FOR_CCFLUSH)
 static NTSTATUS __stdcall fast_io_acquire_for_ccflush(PFILE_OBJECT FileObject, PDEVICE_OBJECT DeviceObject) {
-    UNUSED(FileObject);
+    fcb* fcb;
+
+    TRACE("(%p, %p)\n", FileObject, DeviceObject);
+
     UNUSED(DeviceObject);
+
+    fcb = FileObject->FsContext;
+
+    if (!fcb)
+        return STATUS_INVALID_PARAMETER;
+
+    ExAcquireResourceSharedLite(&fcb->Vcb->tree_lock, true);
+    ExAcquireResourceExclusiveLite(fcb->Header.Resource, true);
 
     IoSetTopLevelIrp((PIRP)FSRTL_CACHE_TOP_LEVEL_IRP);
 
@@ -333,8 +344,16 @@ static NTSTATUS __stdcall fast_io_acquire_for_ccflush(PFILE_OBJECT FileObject, P
 
 _Function_class_(FAST_IO_RELEASE_FOR_CCFLUSH)
 static NTSTATUS __stdcall fast_io_release_for_ccflush(PFILE_OBJECT FileObject, PDEVICE_OBJECT DeviceObject) {
-    UNUSED(FileObject);
+    fcb* fcb;
+
+    TRACE("(%p, %p)\n", FileObject, DeviceObject);
+
     UNUSED(DeviceObject);
+
+    fcb = FileObject->FsContext;
+
+    ExReleaseResourceLite(fcb->Header.Resource);
+    ExReleaseResourceLite(&fcb->Vcb->tree_lock);
 
     if (IoGetTopLevelIrp() == (PIRP)FSRTL_CACHE_TOP_LEVEL_IRP)
         IoSetTopLevelIrp(NULL);


### PR DESCRIPTION
seems to fix various deadlock scenarios when writing in windows 11

what appears to happen is that ccflush magically acquires locks if we don't acquire them explicitly. this then results in a deadlock where the ccflush thread is holding the lock and waiting for writing to happen (somewhere inside CcFlushCacheOneRange). meanwhile one of our threads is stuck waiting for the lock (somewhere inside drv_write).

(I am not super sure that is the right thing to do, but looking at ext4fsd it also implements these functions with actual acquire and release. also I don't understand the implications of FSRTL_CACHE_TOP_LEVEL_IRP)