### PR TITLE
fsctl: prevent kernel pool overrun in `duplicate_extents` inline path

### DIFF
--- a/src/fsctl.c
+++ b/src/fsctl.c
@@ -3380,9 +3380,16 @@ static NTSTATUS duplicate_extents(device_extension* Vcb, PFILE_OBJECT FileObject
 
     if (fcb->ads || sourcefcb->ads || make_inline || fcb_is_inline(sourcefcb)) {
         uint8_t* data2;
-        ULONG bytes_read, dataoff, datalen2;
+        ULONG bytes_read, dataoff, datalen2, to_read;
 
         if (make_inline) {
+            // Inline extents store exactly st_size bytes; reject ranges that
+            // don't fit so the source read below cannot scribble past data2.
+            if ((uint64_t)ded->TargetFileOffset.QuadPart > (uint64_t)fcb->inode_item.st_size) {
+                Status = STATUS_INVALID_PARAMETER;
+                goto end;
+            }
+
             dataoff = (ULONG)ded->TargetFileOffset.QuadPart;
             datalen2 = (ULONG)fcb->inode_item.st_size;
         } else if (fcb->ads) {
@@ -3413,15 +3420,20 @@ static NTSTATUS duplicate_extents(device_extension* Vcb, PFILE_OBJECT FileObject
             }
         }
 
+        // Clamp the source read to the space remaining in data2. For
+        // make_inline this is needed because Explorer's reflink paste rounds
+        // ByteCount up to the cluster size, which can exceed st_size.
+        to_read = (ULONG)min((uint64_t)ded->ByteCount.QuadPart, (uint64_t)(datalen2 - dataoff));
+
         if (sourcefcb->ads) {
-            Status = read_stream(sourcefcb, data2 + dataoff, ded->SourceFileOffset.QuadPart, (ULONG)ded->ByteCount.QuadPart, &bytes_read);
+            Status = read_stream(sourcefcb, data2 + dataoff, ded->SourceFileOffset.QuadPart, to_read, &bytes_read);
             if (!NT_SUCCESS(Status)) {
                 ERR("read_stream returned %08lx\n", Status);
                 ExFreePool(data2);
                 goto end;
             }
         } else {
-            Status = read_file(sourcefcb, data2 + dataoff, ded->SourceFileOffset.QuadPart, ded->ByteCount.QuadPart, &bytes_read, Irp);
+            Status = read_file(sourcefcb, data2 + dataoff, ded->SourceFileOffset.QuadPart, to_read, &bytes_read, Irp);
             if (!NT_SUCCESS(Status)) {
                 ERR("read_file returned %08lx\n", Status);
                 ExFreePool(data2);
@@ -3430,11 +3442,19 @@ static NTSTATUS duplicate_extents(device_extension* Vcb, PFILE_OBJECT FileObject
         }
 
         if (dataoff + bytes_read < datalen2)
-            RtlZeroMemory(data2 + dataoff + bytes_read, datalen2 - bytes_read);
+            RtlZeroMemory(data2 + dataoff + bytes_read, datalen2 - dataoff - bytes_read);
 
-        if (fcb->ads)
-            RtlCopyMemory(&fcb->adsdata.Buffer[ded->TargetFileOffset.QuadPart], data2, (USHORT)min(ded->ByteCount.QuadPart, fcb->adsdata.Length - ded->TargetFileOffset.QuadPart));
-        else if (make_inline) {
+        if (fcb->ads) {
+            USHORT copylen;
+
+            if ((uint64_t)ded->TargetFileOffset.QuadPart >= fcb->adsdata.Length)
+                copylen = 0;
+            else
+                copylen = (USHORT)min((uint64_t)ded->ByteCount.QuadPart,
+                                      (uint64_t)(fcb->adsdata.Length - ded->TargetFileOffset.QuadPart));
+
+            RtlCopyMemory(&fcb->adsdata.Buffer[ded->TargetFileOffset.QuadPart], data2, copylen);
+        } else if (make_inline) {
             uint16_t edsize;
             EXTENT_DATA* ed;
 

--- a/src/fsctl.c
+++ b/src/fsctl.c
@@ -3369,9 +3369,14 @@ static NTSTATUS duplicate_extents(device_extension* Vcb, PFILE_OBJECT FileObject
 
     if (fcb->ads || sourcefcb->ads || make_inline || fcb_is_inline(sourcefcb)) {
         uint8_t* data2;
-        ULONG bytes_read, dataoff, datalen2;
+        ULONG bytes_read, dataoff, datalen2, to_read;
 
         if (make_inline) {
+            if ((uint64_t)ded->TargetFileOffset.QuadPart > (uint64_t)fcb->inode_item.size) {
+                Status = STATUS_INVALID_PARAMETER;
+                goto end;
+            }
+
             dataoff = (ULONG)ded->TargetFileOffset.QuadPart;
             datalen2 = (ULONG)fcb->inode_item.size;
         } else if (fcb->ads) {
@@ -3402,15 +3407,19 @@ static NTSTATUS duplicate_extents(device_extension* Vcb, PFILE_OBJECT FileObject
             }
         }
 
+        to_read = (ULONG)min((uint64_t)ded->ByteCount.QuadPart, (uint64_t)(datalen2 - dataoff));
+
         if (sourcefcb->ads) {
-            Status = read_stream(sourcefcb, data2 + dataoff, ded->SourceFileOffset.QuadPart, (ULONG)ded->ByteCount.QuadPart, &bytes_read);
+            Status = read_stream(sourcefcb, data2 + dataoff, ded->SourceFileOffset.QuadPart,
+                                 to_read, &bytes_read);
             if (!NT_SUCCESS(Status)) {
                 ERR("read_stream returned %08lx\n", Status);
                 ExFreePool(data2);
                 goto end;
             }
         } else {
-            Status = read_file(sourcefcb, data2 + dataoff, ded->SourceFileOffset.QuadPart, ded->ByteCount.QuadPart, &bytes_read, Irp);
+            Status = read_file(sourcefcb, data2 + dataoff, ded->SourceFileOffset.QuadPart,
+                               to_read, &bytes_read, Irp);
             if (!NT_SUCCESS(Status)) {
                 ERR("read_file returned %08lx\n", Status);
                 ExFreePool(data2);
@@ -3419,11 +3428,16 @@ static NTSTATUS duplicate_extents(device_extension* Vcb, PFILE_OBJECT FileObject
         }
 
         if (dataoff + bytes_read < datalen2)
-            RtlZeroMemory(data2 + dataoff + bytes_read, datalen2 - bytes_read);
+            RtlZeroMemory(data2 + dataoff + bytes_read, datalen2 - dataoff - bytes_read);
 
-        if (fcb->ads)
-            RtlCopyMemory(&fcb->adsdata.Buffer[ded->TargetFileOffset.QuadPart], data2, (USHORT)min(ded->ByteCount.QuadPart, fcb->adsdata.Length - ded->TargetFileOffset.QuadPart));
-        else if (make_inline) {
+        if (fcb->ads) {
+            USHORT copylen;
+
+            if ((uint64_t)ded->TargetFileOffset.QuadPart < fcb->adsdata.Length) {
+                RtlCopyMemory(&fcb->adsdata.Buffer[ded->TargetFileOffset.QuadPart], data2,
+                              (USHORT)min((uint64_t)ded->ByteCount.QuadPart, (uint64_t)(fcb->adsdata.Length - ded->TargetFileOffset.QuadPart)));
+            }
+        } else if (make_inline) {
             uint16_t edsize;
             struct btrfs_file_extent_item* ed;
 


### PR DESCRIPTION
Fixes #789.

Fixes a deterministic BSOD `0x139 (0x1d)` (`FAST_FAIL_INVALID_BALANCED_TREE`) on `FSCTL_DUPLICATE_EXTENTS_TO_FILE` when the destination file is small enough to be stored as an inline EXTENT_DATA (`st_size ≤ max_inline`, default 2048 bytes).

## TL;DR

Right-click -> Reflink Paste in Explorer hard-crashes Windows on any small file (≤ 2 KB on default settings) that lives on a btrfs volume converted from NTFS by `ntfs2btrfs`.
Bug check `0x139 (0x1d)`, deterministic, first try.

The driver's inline-extent path allocates a buffer the size of the file's content, then reads the caller's full byte count into it.
shellbtrfs rounds that byte count up to the cluster size, so a 100-byte file gets a 4 KB read into a 100-byte buffer.
The corruption only surfaces later on the next pool allocation in some unrelated driver, which is why the original dumps' stacks sit at innocent btrfs offsets via `RtlRbInsertNodeEx`.

Fix is a one-line clamp on the read length, plus three nearby buffer-math tightenings of the same flavor.
One function, 27 lines added, 7 removed.

Verified under Driver Verifier with Special Pool on the patched driver: original repro completes clean.
For a control I reinstalled stock 1.9.0 from the official INF: same `0x139 (0x1d)` BSOD.

## Reproduction

1. Mount a BTRFS volume created by `ntfs2btrfs.exe` (every live inode reflinked from `<vol>\image\ntfs.img`).
2. Install `shellbtrfs.dll` so Explorer exposes "Reflink Paste".
3. Copy any small file (≤ `max_inline`) inside the volume.
4. Right-click in another folder on the same volume, then **Reflink Paste**.

Trips on the first attempt.
Two attached minidumps in the linked report show the same trip site and different `btrfs+offset` frames; those offsets are innocent allocation sites.
The corrupting write happens earlier and only surfaces on the next pool allocation.

## Root cause

`duplicate_extents` in [src/fsctl.c](../src/fsctl.c) takes the `make_inline` branch when the destination is inline-sized.
It allocates `data2` of `fcb->inode_item.st_size` bytes, then reads `ded->ByteCount.QuadPart` bytes from the source into that buffer:

```c
data2 = ExAllocatePoolWithTag(PagedPool, datalen2, ALLOC_TAG);
//                                       ^^^^^^^^ = st_size, e.g. 100
...
read_file(sourcefcb, data2 + dataoff, SourceFileOffset,
          ded->ByteCount.QuadPart,    // <= caller-controlled, can be 4096
          &bytes_read, Irp);
```

Explorer's `BtrfsContextMenu::reflink_copy` rounds `ByteCount` up to the cluster size (`sector_align(EndOfFile, ClusterSize)`), so a 100-byte file with a 4 KB cluster yields `ByteCount = 4096`.
When the source has a `REGULAR` on-disk extent that size (which every ntfs2btrfs-reflinked file does, regardless of its logical size), `read_file` writes ~4 KB into the 100-byte `data2`.
That stomps adjacent kernel pool, and the next allocation triggers a fast-fail in the pool free-chunk RB-tree.

## Fix

Four small changes inside the `make_inline || ads || …` block, all in [src/fsctl.c](../src/fsctl.c)::`duplicate_extents`.
Diff is 27 insertions / 7 deletions, no on-disk format change, no new APIs.

1. **Clamp the source read to the remaining buffer space.**
   Compute `to_read = min(ByteCount, datalen2 - dataoff)` and pass it to `read_file` / `read_stream`.
   The other branches (non-inline, non-ads) already sized `datalen2` to `sector_align(ByteCount + dataoff)`, so this is a no-op for them.
2. **Reject `TargetFileOffset > st_size` on the inline path.**
   Otherwise `dataoff > datalen2` and the prefix `read_file` overruns too.
   Returns `STATUS_INVALID_PARAMETER`.
3. **Fix the trailing `RtlZeroMemory` size.**
   Was `datalen2 - bytes_read` (end offset overshoots by `dataoff`), now `datalen2 - dataoff - bytes_read`.
   Latent: doesn't trigger in the reported repro because Explorer always sets `TargetFileOffset=0`, but any programmatic caller with non-zero offset would hit it.
4. **Guard the ADS `RtlCopyMemory` length against underflow.**
   `min(ByteCount, adsdata.Length - TargetFileOffset)` cast to `USHORT` could let up to 64 KB be written past the ADS buffer when `TargetFileOffset > Length`.
   Replaced with an explicit `>= Length → 0` check.
   Latent: Explorer's reflink path doesn't target streams.

## Design rationale

### Why a clamp

An inline EXTENT_DATA stores exactly `st_size` bytes of file content in the metadata tree, by definition of the BTRFS on-disk format.
Bytes beyond `st_size` have nowhere to go in inline storage, so the natural buffer bound is `min(ByteCount, st_size - target_offset)`.
Inline extents additionally cannot be physically shared between files, so the `make_inline` path is "copy" semantics, not "share" semantics, by construction.
Linux btrfs's `FICLONE` handles small inline extents the same way.

### What the spec says

[Block Cloning, "Restrictions and Remarks"](https://learn.microsoft.com/en-us/windows/win32/fileio/block-cloning):

> "The destination region must not extend past the end of file. If the application wishes to extend the destination with cloned data, it must first call SetEndOfFile."

Strictly per spec, a request where `TargetFileOffset + ByteCount > EndOfFile` is invalid input.

### What `shellbtrfs` does today

`BtrfsContextMenu::reflink_copy` in `src/shellext/contextmenu.cpp` sets `dst.EOF := src.EOF`, then issues the FSCTL with `ByteCount = sector_align(src.EOF, cluster_size)`.
For any non-cluster-aligned source file that puts `TargetFileOffset + ByteCount > EOF`, exactly the case the spec forbids.
That has been true since the reflink-copy shell action shipped, independently of this PR.
A kernel driver still has to defend against it: input from user mode is untrusted regardless of who the caller is.

### One real alternative: strict reject

The only fix that competes with the clamp on review is to return `STATUS_INVALID_PARAMETER` whenever the destination range extends past EOF.
That is the spec-strict choice and the right long-term answer.
It is not undertaken in this PR because the canonical caller is `shellbtrfs`, which would have to be updated in the same change to extend the destination EOF (or pass a smaller `ByteCount`) before issuing the FSCTL.
Without a paired `shellbtrfs` fix, every Reflink-Paste of a non-cluster-aligned file would regress from a (now-fixed) BSOD into a user-visible "Reflink Paste failed".
The clamp does not preclude that tightening: replacing it with a reject is a one-line change once `shellbtrfs` moves.

## Verification

Built against current WDK 10.0.26100, test-signed, replaced `C:\Windows\System32\drivers\btrfs.sys` via boot-time `MoveFileEx`.
Driver Verifier enabled with **Special Pool**, **Pool Tracking**, **Force IRQL Checking**, **I/O Verification**, and **IRP Logging** on `btrfs.sys` only.

Special Pool puts each `ExAllocatePool*` allocation on its own page with a guard page after, so a one-byte overrun bug-checks *at the instruction doing the bad write*, not deferred until a later RB-tree insertion.
The patched driver completed the original Reflink Paste repro on the same ntfs2btrfs-converted volume with no bug check.
If the original overrun had survived in any form, Verifier would have caught it inside the `read_file` path before `duplicate_extents` returned.

### Post-validation regression check on a clean upstream install

After the patched driver passed Verifier, the original WinBtrfs 1.9.0 was reinstalled on the same machine to confirm the bug still reproduces on a stock, unmodified upstream binary (the loaded `btrfs.sys` SHA-256 matches the distribution: `6E6F8622FCE2E1F03CFE706915A815C5221B085ABBE3F89346A1B95086CD6CB2`).
The reinstall was done via the official `.inf` / `.cat` driver-store registration path (not a raw file copy), so the catalog hashes are present in the kernel CI database and the driver loads under the current Windows 11 24H2 code-integrity policy.
Driver Verifier was off for this run, so any pool corruption surfaces as a deferred catch in some later allocation, exactly like the original report.

Re-running the same Reflink-Paste workflow on the same volume immediately produced bug check `0x139 (0x1d)` (`FAST_FAIL_INVALID_BALANCED_TREE`) with the corruption caught at the next pool allocation (this time inside `dxgkrnl!operator new[]` while NVIDIA Broadcaster was running in the background, the dump is included alongside the original two as `minidumps/042726-23453-01.dmp`).
The trip-site frame moves around between dumps because the corruption catch is deferred, but the failure signature is identical across all three runs and matches the same root cause.